### PR TITLE
#AG-76 bump monterey from 12.2.1 to 12.4

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -50,17 +50,35 @@ Here are some of the most important packages installed in our macOS agents used 
 
 `macOS Monterey v.12.4`
 
-| Package            | Version   |
-| ------------------ | --------- |
-| Bash               | 3.2.57    |
-| Homebrew           | 2.3.0     |
-| Java (OpenJDK)     | 11.0.2    |
-| Git                | 2.24.3    |
-| Gzip (Apple)       | 287.100.2 |
-| LibreSSL (OpenSSL) | 2.8.3     |
-| Node               | 14.3.0    |
-| Perl               | 5.18.4    |
-| Python             | 2.7.16    |
-| Rake               | 12.3.2    |
-| Ruby               | 2.6.3     |
-| RVM                | 1.29.10   |
+| Package            | Version    |
+| ------------------ | ---------- |
+| Bash               | 3.2.57     |
+| Bundle             | 2.3.9      |
+| Carthage           | 0.38.0     |
+| Curl               | 7.79.1     |
+| Homebrew           | 3.4.2      |
+| Java (OpenJDK)     | 11.0.2     |
+| Fastlane           | 2.204.3    |
+| Gem                | 3.1.6      |
+| Git                | 2.35.1     |
+| Git LFS            | 3.1.2      |
+| Gzip (Apple)       | 353.100.22 |
+| LibreSSL (OpenSSL) | 2.8.3      |
+| ImageMagick        | 7.1.0      |
+| Maven              | 3.8.4      |
+| N                  | 8.0.2      |
+| Node               | 16.14.0    |
+| Npm                | 8.3.1      |
+| Perl               | 5.30.3     |
+| Pod                | 1.11.2     |
+| Pip                | 21.3.1     |
+| Python             | 3.9.10     |
+| Rake               | 13.0.1     |
+| Ruby               | 2.7.5      |
+| Rbenv              | 1.2.0      |
+| Sdkman             | 5.14.0     |
+| Slather            | 2.7.2      |
+| Unzip              | 6.00       |
+| Xcodeproj          | 1.21.0     |
+| Yarn               | 1.22.17    |
+| Zip                | 3.0        |

--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -6,20 +6,19 @@ sidebar_position: 1
 ---
 # iOS Build Infrastructure
 
-Depending on which Xcode version you select, Appcircle creates a brand new virtual machine running `macOS (v.10.15 Catalina)` or `macOS (v.12.3.1 Monterey)`
+Depending on which Xcode version you select, Appcircle creates a brand new virtual machine running `macOS (v.10.15.7 Catalina)` or `macOS (v.12.4 Monterey)`
 
 :::tip
 
-For Xcode version **13.0.x** and **12.5.x**, `macOS (v.12.3.1 Monterey)` is used. For every other versions, `macOS (v.10.15 Catalina)` is used.
+For Xcode versions **14.0.x**, **13.4.x**, **13.3.x**, **13.2.x**, **13.1.x**, **13.0.x** and **12.5.x**, `macOS (v.12.4 Monterey)` is used. For every other versions, `macOS (v.10.15.7 Catalina)` is used.
 
 :::
 
-macOS X images run on a fresh Vagrant environment for stability and performance. They are created just for your build and become ready within seconds.
+macOS images run on a fresh Docker environment for stability and performance. They are created just for your build and become ready within seconds.
 
-During the build process, you can install any dependencies and run commands using custom scrip steps in the build workflow. This gives you complete control over your build and the virtual machine.
+During the build process, you can install any dependencies and run commands using "custom script" steps in the build workflow. This gives you complete control over your build and the virtual machine.
 
 :::info
-
 
 Please note that virtual machines are wiped off after a build is executed (no matter success or fail) and anything you installed in the virtual machine will be gone.
 
@@ -41,13 +40,15 @@ Appcircle supports using a 3rd party computer to perform builds. You can create 
 
 ### Available Xcode Versions
 
-Our macOS build agents have Xcode versions 13.3.x, 13.2.x, 13.1.x, 13.0, 12.5, 12.4, 12.3, 12.2, 12.1, 12.0, 11.7, 11.6, 11.5, 11.4, 11.3, 11.2, 11.1 and 11.0 available.;
+Our macOS build agents have Xcode versions 14.0.x, 13.4.x, 13.3.x, 13.2.x, 13.1.x, 13.0, 12.5, 12.4, 12.3, 12.2, 12.1, 12.0, 11.7, 11.6, 11.5, 11.4, 11.3, 11.2, 11.1 and 11.0 available.
 
 ### macOS Build Agent Stacks
 
-There are many pre-installed packages in virtual machines. You can get a full list of pre-installed packages by running Bash commands in custom script steps.;
+There are many pre-installed packages in virtual machines. You can get a full list of pre-installed packages by running Bash commands in "custom script" steps.
 
 Here are some of the most important packages installed in our macOS agents used for iOS builds:
+
+`macOS Monterey v.12.4`
 
 | Package            | Version   |
 | ------------------ | --------- |


### PR DESCRIPTION
I've edited iOS build infrastructure doc according to latest macOS Monterey changes.

- Add missing Xcode versions to doc
- Update patch version of Catalina
- Update minor version of Monterey
- Update package versions table
- Fix other minor typos in text