### PR TITLE
Release v2.9.13

### DIFF
--- a/docs/account/adding-an-app-store-connect-api-key.md
+++ b/docs/account/adding-an-app-store-connect-api-key.md
@@ -2,7 +2,7 @@
 title: Adding an App Store Connect API Key
 metaTitle: Adding an App Store Connect API Key
 metaDescription: Adding an App Store Connect API Key
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Adding an App Store Connect API Key

--- a/docs/account/adding-google-play-service-account.md
+++ b/docs/account/adding-google-play-service-account.md
@@ -2,7 +2,7 @@
 title: Adding a Google Play Service Account
 metaTitle: Adding a Google Play Service Account
 metaDescription: Adding a Google Play Service Account
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Adding a Google Play Service Account

--- a/docs/account/adding-huawei-api-key.md
+++ b/docs/account/adding-huawei-api-key.md
@@ -2,7 +2,7 @@
 title: Adding Huawei AppGallery API Key
 metaTitle: Adding Huawei AppGallery API Key
 metaDescription: Adding Huawei AppGallery API Key
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Adding Huawei AppGallery API Key

--- a/docs/account/artifacts.md
+++ b/docs/account/artifacts.md
@@ -1,0 +1,15 @@
+---
+title: Artifacts
+metaTitle: Artifacts
+metaDescription: Artifacts
+sidebar_position: 3
+---
+
+# Artifacts
+
+The logs and artifacts of your build profiles can be managed on the artifacts section.Build artifacts and logs are deleted according to retention period. Artifacts retention period depends on your license. 
+
+- Starter accounts can't manage the retention period. After 30 days, logs and artifacts will be automatically deleted. 
+- Professional or higher plans can manage the retention period. Those plans can set 30,60,90,180 or 365 days for a retention period. Paid plans can also choose **never delete** option and manage their artifacts manually.
+
+![](<https://cdn.appcircle.io/docs/assets/account-artifacts.png>)

--- a/docs/account/my-organization.md
+++ b/docs/account/my-organization.md
@@ -2,7 +2,7 @@
 title: My Organization and Team Management
 metaTitle: My Organization and Team Management
 metaDescription: My Organization and Team Management
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # My Organization and Team Management

--- a/docs/account/slack-notifications.md
+++ b/docs/account/slack-notifications.md
@@ -2,7 +2,7 @@
 title: Slack Notifications
 metaTitle: Slack Notifications
 metaDescription: Slack Notifications
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Slack Notifications

--- a/docs/integrations/increasing-the-version-number-automatically-for-ios-and-android.md
+++ b/docs/integrations/increasing-the-version-number-automatically-for-ios-and-android.md
@@ -38,6 +38,11 @@ if (System.getenv("AC_APPCIRCLE")) {
 }
 ```
 
+If you want to have better control over `versionCode` and `versionName` management, you may also use the Android Versioning component. Please check the following document for more information.
+
+<ContentRef url="/versioning/android-version">
+  Android Versioning
+</ContentRef>
 
 For iOS, you should use the Versioning Tab on your config screen to manage the build and version number. Please check the following document to learn more about the iOS Versioning system.
 

--- a/docs/integrations/working-with-custom-scripts/custom-script-samples.md
+++ b/docs/integrations/working-with-custom-scripts/custom-script-samples.md
@@ -52,7 +52,7 @@ The sample script is as follows:
 #
 # Deploy a binary to Firebase App Distribution
 #
-npm install -g firebase-tools
+curl -sL firebase.tools | bash
 
 firebase appdistribution:distribute $AC_EXPORT_DIR/Runner.ipa --app $FIREBASE_APP_ID --release-notes "Release Notes..." --token $FIREBASE_TOKEN --groups "testers"
 ```

--- a/docs/signing-identities/ios-certificates-and-provisioning-profiles.md
+++ b/docs/signing-identities/ios-certificates-and-provisioning-profiles.md
@@ -81,7 +81,7 @@ You can use the Appcircle Distribute module or the Enterprise App Store module t
 
 There is no need for device registration, but Apple requires the binary to be protected and not open for public download, so you can use the enrollment feature of the Appcircle Distribute module to protect the app distribution.
 
-## Using the Appcircle Signing Identities Module for iOS;
+## Using the Appcircle Signing Identities Module for iOS
 
 ### 1. Get iOS Provisioning Profiles from Apple
 
@@ -93,15 +93,34 @@ There is no need for device registration, but Apple requires the binary to be pr
 
 When you go to add a new Provisioning Profile, you'll see the option **Get Provisioning Profiles from App Store Connect**. Select it to see the list of identities fetched from Apple.
 
-![](https://cdn.appcircle.io/docs/assets/add-certificates-2-low.jpg)
+![](https://cdn.appcircle.io/docs/assets/download-provisioning.png)
 
 You can select to download the provisioning profile from the list. **If you don't want Appcircle to keep the provisioning profile**, you can make our build agents to keep a reference. This way, our agents will fetch the profiles** before every build and dismiss them **when the build is finalized.
 
-![](https://cdn.appcircle.io/docs/assets/certificate-list-2-low.jpg)
+![](https://cdn.appcircle.io/docs/assets/provisioning-list.png)
 
 After saving, you can **skip to step 3**.
 
-### 2. Generate Or Upload iOS Certificates
+### 2. Upload iOS Provisioning Profiles
+
+Simply upload your provisioning profiles obtained from the Apple Developer portal.
+
+![](https://cdn.appcircle.io/docs/assets/02-03-Upload-Provisioning-Profile.jpg)
+
+:::info
+
+Provisioning profile and certificate matching will be done automatically. You can also have multiple provisioning profiles to use in different applications with different Apple developer accounts.
+
+:::
+
+You can list and manage your provisioning profiles here. If there is a matching certificate, the profile will show a green check mark to indicate that. If not, you will see a red cross mark indicating there's no certificate matching the provisioning profile.
+
+You can also see the matching application ID and expiration date of the profiles here.
+
+![](https://cdn.appcircle.io/docs/assets/02-07-Provision-Details.jpg)
+
+
+### 3. Generate Or Upload iOS Certificates
 
 To generate or upload your iOS certificate, select **iOS Certificates** from the signing module.
 
@@ -165,27 +184,33 @@ If your password contains special characters such as `$` and `#`, your workflow 
 
 ![](https://cdn.appcircle.io/docs/assets/02-08-CertificateList.jpg)
 
-### 2. Upload iOS Provisioning Profiles
+### Assign signing identities in the Build module for distribution
 
-Simply upload your provisioning profiles obtained from the Apple Developer portal.
+For both iOS or Android build projects, you need to assign your signing identities to your build profile for distribution. The distribution-ready binaries will be signed with the selected signing identities both in manual and automatic distribution cases.
 
-![](https://cdn.appcircle.io/docs/assets/02-03-Upload-Provisioning-Profile.jpg)
+You can sign your application either with automatic signing or with manual signing.
 
-:::info
+### Automatic Signing
+Automatic signing allows you to sign your application without uploading any provisioning profiles. Profile creation is done automatically by Xcode. Following prequisites must be met for automatic signing to work:
 
-Provisioning profile and certificate matching will be done automatically. You can also have multiple provisioning profiles to use in different applications with different Apple developer accounts.
+- Project must be built with Xcode 13 or higher.
+- Both Developer and Distribution certificates must be added to Appcircle.
+- App Store Connect Key must be added to Appcircle. 
+
+![](https://cdn.appcircle.io/docs/assets/auto-codesign.png)
+
+You must also select distribution type from the dropdown menu. If you're uploading your app to App Store or TestFlight, you should select **App Store**. If you're uploading your app to Adhoc or Appcircle's distribution module, you should select **Adhoc**. Please check [Apple's documentation](https://developer.apple.com/documentation/technotes/tn3125-inside-code-signing-provisioning-profiles) for more details.
+
+:::warning
+
+If you don't upload developer and distribution certificates, Xcode will create new certificates each time you start a build. Since you don't have the private keys, you will not be able to use those certificates later on. If you don't want to clutter your account with unused certificates, you must upload both developer and distribution certificates.
 
 :::
 
-You can list and manage your provisioning profiles here. If there is a matching certificate, the profile will show a green check mark to indicate that. If not, you will see a red cross mark indicating there's no certificate matching the provisioning profile.
 
-You can also see the matching application ID and expiration date of the profiles here.
+### Manual Signing
 
-![](https://cdn.appcircle.io/docs/assets/02-07-Provision-Details.jpg)
-
-### **3. Assign signing identities in the Build module for distribution**
-
-For both iOS or Android build projects, you need to assign your signing identities to your build profile for distribution. The distribution-ready binaries will be signed with the selected signing identities both in manual and automatic distribution cases.
+You can also select bundle identifier and provisioning profile to sign your application.
 
 ![](https://cdn.appcircle.io/docs/assets/03-02-iOS-Build-Signing.jpg)
 

--- a/docs/updates/release-notes.md
+++ b/docs/updates/release-notes.md
@@ -9,6 +9,23 @@ import ContentRef from '@site/src/components/ContentRef';
 
 # Latest Release Notes
 
+## 2.9.13 - 2022-07-27 - Self-hosted Runners, Artifacts Management, Automatic iOS Code Signing
+
+### 🆕 New Feature
+- [Self-Hosted Runners](../self-hosted-runner/overview.md) Self-hosted runner enables you to use your own systems and infrastructure for running Appcircle build pipelines. 
+- [Automatic iOS Code Signing](../signing-identities/ios-certificates-and-provisioning-profiles.md) If you're using Xcode 13 or later, you can now use the automatic code signing option to automatically sign your iOS apps.
+- [Artifacts Management](../account/artifacts.md) You can set the retention period for your build artifacts.
+- [SonarQube Component](../workflows/common-workflow-steps.md) You can use SonarQube for iOS and Android projects.
+
+### :muscle: Improvement
+- Slack messages updated to include store name and distribution links.
+- Android v2 signing support improved.
+
+### 🐞 Fixed
+
+- `Get help with build errors` link fixed.
+- Renaming build profiles fixed.
+
 ## 2.9.12 - 2022-07-07 - Android Version Management, Enterprise Store Improvements
 
 ### 🆕 New Feature

--- a/docs/workflows/common-workflow-steps.md
+++ b/docs/workflows/common-workflow-steps.md
@@ -93,3 +93,9 @@ Also you can have more than one push and pull pairs in the same build pipeline a
 You can use Release Notes component to create release notes during your workflow.
 
 [https://github.com/appcircleio/appcircle-release-notes-component](https://github.com/appcircleio/appcircle-release-notes-component)
+
+## SonarQube
+
+You can use SonarQube component to check your code quality.
+
+[https://github.com/appcircleio/appcircle-sonarqube-component](https://github.com/appcircleio/appcircle-sonarqube-component)


### PR DESCRIPTION
- [Self-Hosted Runners](../self-hosted-runner/overview.md) Self-hosted runner enables you to use your own systems and infrastructure for running Appcircle build pipelines. 
- [Automatic iOS Code Signing](../signing-identities/ios-certificates-and-provisioning-profiles.md) If you're using Xcode 13 or later, you can now use the automatic code signing option to automatically sign your iOS apps.
- [Artifacts Management](../account/artifacts.md) You can set the retention period for your build artifacts.
- [SonarQube Component](../workflows/common-workflow-steps.md) You can use SonarQube for iOS and Android projects.

### :muscle: Improvement
- Slack messages updated to include store name and distribution links.
- Android v2 signing support improved.

### 🐞 Fixed

- `Get help with build errors` link fixed.
- Renaming build profiles fixed.
