### PR TITLE
#AG-112 Add m1 cloud outbound IP

### DIFF
--- a/docs/infrastructure/accessing-repositories-in-internal-networks-firewalls.md
+++ b/docs/infrastructure/accessing-repositories-in-internal-networks-firewalls.md
@@ -18,5 +18,6 @@ Appcircle requires direct access to the repositories for the following use cases
 If the repositories cannot be exposed to the public internet in general, the following Appcircle platform IP addresses must be allowed through the firewall (whitelisted) to access such repositories:
 
 * 34.147.2.16
+* 77.92.96.46
 
 You can then [connect to the repository through SSH](../build/adding-a-build-profile/#connect-your-repository) just like connecting to any Git provider.


### PR DESCRIPTION
All `m1` cloud runners have same outbound IP which should be whitelisted on customer-side if necessary.