### PR TITLE
#BE-997 Bump self-hosted appcircle version to 3.0.0

### DIFF
--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -42,13 +42,13 @@ You need to have the following tools installed on your system:
 Download the latest self-hosted appcircle package.
 
 ```bash
-curl -o appcircle-server-linux-x64-1.0.4.zip -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-1.0.4.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.0.0.zip
 ```
 
 Extract self-hosted appcircle package into folder.
 
 ```bash
-unzip -o -u appcircle-server-linux-x64-1.0.4.zip -d appcircle-server
+unzip -o -u appcircle-server-linux-x64-3.0.0.zip -d appcircle-server
 ```
 
 Change directory into extracted `appcircle-server` folder for following steps.

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -30,13 +30,13 @@ Below steps does not affect or destroy your data. Update process keeps your data
 Download the latest self-hosted appcircle package.
 
 ```bash
-curl -o appcircle-server-linux-x64-1.0.4.zip -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-1.0.4.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.0.0.zip
 ```
 
 Extract self-hosted appcircle package into folder.
 
 ```bash
-unzip -o -u appcircle-server-linux-x64-1.0.4.zip -d appcircle-server
+unzip -o -u appcircle-server-linux-x64-3.0.0.zip -d appcircle-server
 ```
 
 Change directory into extracted `appcircle-server` folder for following steps.


### PR DESCRIPTION
It's an important milestone for self-hosted appcircle server. :smile: 

I changed `curl` in order to keep it short and bumped `.zip` package version.