### PR TITLE
#BE-1127 Update docs for 3.1.0

### DIFF
--- a/docs/self-hosted-appcircle/git-providers.md
+++ b/docs/self-hosted-appcircle/git-providers.md
@@ -108,7 +108,7 @@ docker compose down
 
 ```bash
 cd ../../../
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 3. Boot appcircle server.

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -90,13 +90,13 @@ You need to have the following tools installed on your system:
 Download the latest self-hosted appcircle package.
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.0.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.1.0.zip
 ```
 
 Extract self-hosted appcircle package into folder.
 
 ```bash
-unzip -o -u appcircle-server-linux-x64-3.0.0.zip -d appcircle-server
+unzip -o -u appcircle-server-linux-x64-3.1.0.zip -d appcircle-server
 ```
 
 Change directory into extracted `appcircle-server` folder for following steps.

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -181,7 +181,7 @@ If `docker-compose-plugin` is missing in your system, follow its [docs](https://
 First we need to find a name to our self-hosted appcircle installation. It will be the unique project name.
 
 ```bash
-./ac-self-hosted.sh -n "${YOUR_PROJECT}"
+./ac-self-hosted.sh -n "${YOUR_PROJECT}" export
 ```
 
 Let's assume we have company named as Space Tech. Then our project name can be "spacetech". For following steps, we will give examples based on this fictive company for better understanding.
@@ -189,7 +189,7 @@ Let's assume we have company named as Space Tech. Then our project name can be "
 Then our command to execute will be:
 
 ```bash
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 :::info
@@ -215,7 +215,7 @@ cp ~/Downloads/space-tech-cred.json cred.json
 After that you can execute below command.
 
 ```bash
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 You should see
@@ -389,7 +389,7 @@ docker compose down -v
 After updating initial password, to activate changes, you need to do fresh export before running services.
 
 ```bash
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 :::
@@ -449,7 +449,7 @@ If you defined all of them in `global.yaml`,simply remove `user-secret` before n
 Note that after changes made to yaml files, you must execute the script again for the changes to take effect as shown below.
 
 ```bash
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 ### 4. DNS Settings
@@ -701,7 +701,7 @@ For our example scenario, root directory is `appcircle-server` as seen [here](./
 :::
 
 ```bash
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 Now you are ready to restart self-hosted appcircle.

--- a/docs/self-hosted-appcircle/overview.md
+++ b/docs/self-hosted-appcircle/overview.md
@@ -12,7 +12,7 @@ By this way, you can build and test your apps on your choice of architectures. Y
 
 When we look at self-hosted Appcircle deployment as a whole, we will see below arhitecture in execution.
 
-![](https://cdn.appcircle.io/docs/assets/self-hosted_appcircle.png)
+![](https://cdn.appcircle.io/docs/assets/self-hosted_appcircle_v3.png)
 
 With the help of self-hosted runners as connected agents, you can have whole Appcircle in your own infrastructure and use all Appcircle features in your private cloud without any limitations.
 

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -93,7 +93,7 @@ In most cases, you don't need to change anything in your configuration. So, abov
 Then execute below command to update server.
 
 ```bash
-./ac-self-hosted.sh -n "spacetech"
+./ac-self-hosted.sh -n "spacetech" export
 ```
 
 For other details and troubleshooting, you can refer to [configuration](./installation.md#3-configure) section in installation docs.

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -30,13 +30,13 @@ Below steps does not affect or destroy your data. Update process keeps your data
 Download the latest self-hosted appcircle package.
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.0.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.1.0.zip
 ```
 
 Extract self-hosted appcircle package into folder.
 
 ```bash
-unzip -o -u appcircle-server-linux-x64-3.0.0.zip -d appcircle-server
+unzip -o -u appcircle-server-linux-x64-3.1.0.zip -d appcircle-server
 ```
 
 Change directory into extracted `appcircle-server` folder for following steps.

--- a/docs/self-hosted-runner/installation.md
+++ b/docs/self-hosted-runner/installation.md
@@ -85,26 +85,26 @@ Download the latest self-hosted runner package.
   <TabItem value="osx-x64" label="macOS x64" default>
 
    ```bash
-curl -o appcircle-runner-osx-x64-1.3.9.zip -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.3.9.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.3.11.zip
 ```
 
 Extract self-hosted runner package.
 
    ```bash
-unzip -o -u appcircle-runner-osx-x64-1.3.9.zip
+unzip -o -u appcircle-runner-osx-x64-1.3.11.zip
 ```
 
   </TabItem>
   <TabItem value="osx-arm64" label="macOS arm64">
 
    ```bash
-curl -o appcircle-runner-osx-arm64-1.3.9.zip -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.3.9.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.3.11.zip
 ```
 
 Extract self-hosted runner package.
 
    ```bash
-unzip -o -u appcircle-runner-osx-arm64-1.3.9.zip
+unzip -o -u appcircle-runner-osx-arm64-1.3.11.zip
 ```
 
   </TabItem>
@@ -112,13 +112,13 @@ unzip -o -u appcircle-runner-osx-arm64-1.3.9.zip
   <TabItem value="linux-x64" label="Linux x64">
 
    ```bash
-curl -o appcircle-runner-linux-x64-1.3.9.zip -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.3.9.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.3.11.zip
 ```
 
 Extract self-hosted runner package.
 
    ```bash
-unzip -o -u appcircle-runner-linux-x64-1.3.9.zip
+unzip -o -u appcircle-runner-linux-x64-1.3.11.zip
 ```
 
   </TabItem>

--- a/docs/self-hosted-runner/update.md
+++ b/docs/self-hosted-runner/update.md
@@ -20,26 +20,26 @@ Download and extract the latest self-hosted runner package.
   <TabItem value="osx-x64" label="macOS x64" default>
 
    ```bash
-curl -o appcircle-runner-osx-x64-1.3.9.zip -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.3.9.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.3.11.zip
 ```
 
 Extract self-hosted runner package.
 
    ```bash
-unzip -o -u appcircle-runner-osx-x64-1.3.9.zip
+unzip -o -u appcircle-runner-osx-x64-1.3.11.zip
 ```
 
   </TabItem>
   <TabItem value="osx-arm64" label="macOS arm64">
 
    ```bash
-curl -o appcircle-runner-osx-arm64-1.3.9.zip -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.3.9.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.3.11.zip
 ```
 
 Extract self-hosted runner package.
 
    ```bash
-unzip -o -u appcircle-runner-osx-arm64-1.3.9.zip
+unzip -o -u appcircle-runner-osx-arm64-1.3.11.zip
 ```
 
   </TabItem>
@@ -47,13 +47,13 @@ unzip -o -u appcircle-runner-osx-arm64-1.3.9.zip
   <TabItem value="linux-x64" label="Linux x64">
 
    ```bash
-curl -o appcircle-runner-linux-x64-1.3.9.zip -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.3.9.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.3.11.zip
 ```
 
 Extract self-hosted runner package.
 
    ```bash
-unzip -o -u appcircle-runner-linux-x64-1.3.9.zip
+unzip -o -u appcircle-runner-linux-x64-1.3.11.zip
 ```
 
   </TabItem>


### PR DESCRIPTION
Latest updates to keep compatibility with `3.1.0` release:
- Update self-hosted appcircle diagram for store submit changes
- Bump self-hosted appcircle version to `3.1.0`
- Update project export commands w/ `export` arg
- Bump self-hosted runner version to `1.3.11`
- Refactor self-hosted runner download command