### PR TITLE
#BE-1107 Add tip section for macOS VM

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -73,6 +73,16 @@ From now on, you will follow same installation steps seen below as other environ
 
 :::
 
+:::tip
+
+#### macOS VM
+
+Appcircle provides ready-to-use macOS VM image especially for enterprise installations. It can be run on macOS Monterey or Ventura `arm64` host.
+
+See details in [here](https://cdn.appcircle.io/docs/assets/how-to-operate-macos-vm-0dd0dc9.pdf).
+
+:::
+
 ## Installation
 
 Adding a self-hosted runner requires that you download, register and configure Appcircle runner in your environment.


### PR DESCRIPTION
We have a PDF file which has details on how to use Appcircle macOS VM image and self-hosted runner it has.

Table of Contents:
- into (reasons to choose VM image)
- requirements (homebrew, tart `0.38.0`)
- getting VM image from Appcircle
- creating base images for 2 runners
- operating there runners (start, stop)
- updating images to persist custom conf.
- troubleshooting guide

Troubleshooting section contains all experiences we got from previous enterprise installations.
___
**Note:** Markdown format is located in https://github.com/appcircleio/ac-script-agent/pull/6

To update PDF our workflow should be,
- Modify markdown file
- Push markdown file
- Export markdown as pdf
- Use git short-SHA in pdf name
- Upload pdf to CDN assets
- Update pdf URL in "tip" section
