### PR TITLE
#BE-1250 fixed loop end of line issue

### DIFF
--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -690,7 +690,7 @@ SRC_REGISTRY_URL="europe-west1-docker.pkg.dev/appcircle/docker-registry"
 DEST_REGISTRY_URL="reg.appcircle.spacetech.com/appcircle"
 
 # Loop through each line of the file and pull, tag, and push the Docker image
-while read IMAGE_NAME; do
+while read -r IMAGE_NAME || [ -n "$IMAGE_NAME" ]; do
     echo "Pulling image: $IMAGE_NAME"
     docker pull $IMAGE_NAME
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
Fixed bug in sample script where last line of file was not being read. 

To fix the issue, I updated the script to ensure that it always reads in the last line of the file, even if there is no newline character at the end of the file.