### PR TITLE
#BE-1298 Update macOS VM image in runner docs

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -80,7 +80,7 @@ From now on, you will follow same installation steps seen below as other environ
 
 Appcircle provides ready-to-use macOS VM image especially for enterprise installations. It can be run on macOS Monterey or Ventura `arm64` host.
 
-See details in [here](https://cdn.appcircle.io/docs/assets/how-to-operate-macos-vm-0dd0dc9.pdf).
+See details in [here](https://cdn.appcircle.io/docs/assets/how-to-operate-macos-vm-d1fdd67.pdf).
 
 :::
 


### PR DESCRIPTION
- Bump the macOS VM image version from `macOS_230309` to `macOS_230510`. (Monterey -> Ventura)
- Update relevant sections for the latest macOS VM image (commands, outputs, etc.).
- Add information about packaged Xcode versions and URLs to build infrastructure pages.