### PR TITLE
#BE-1183 Updated default Xcode version to 14.2

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -197,7 +197,7 @@ You can install iOS platform tools, android platform tools or both of them accor
 
 Below are some example configurations which shows you some sample runner configuration scenarios:
 
-- Install only iOS platform tools with default Xcode (13.4.x)
+- Install only iOS platform tools with default Xcode (14.2.x)
 
 ```bash
 ./ac-runner install -o ios


### PR DESCRIPTION
Updated default Xcode version to 14.2 on runner installation iOS section. If users don't provide a Xcode version on runner installation, 14.2 will be installed by default on the runner. 