### PR TITLE
#BE-964 improved self-hosted documents

### DIFF
--- a/docs/self-hosted-appcircle/git-providers.md
+++ b/docs/self-hosted-appcircle/git-providers.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 # Overview
 
-With default installation, self-hosted appcircle comes with two git providers:
+With default installation, self-hosted Appcircle comes with two git providers:
 
 - Self-hosted Bitbucket
 - Self-hosted GitLab
@@ -97,7 +97,7 @@ Following steps are using example project as project naming, which was told ther
 
 :::
 
-1. Shutdown appcircle server.
+1. Shutdown Appcircle server.
 
 ```bash
 ./ac-self-hosted.sh -n "spacetech" down
@@ -109,12 +109,12 @@ Following steps are using example project as project naming, which was told ther
 ./ac-self-hosted.sh -n "spacetech" export
 ```
 
-3. Boot appcircle server.
+3. Boot Appcircle server.
 
 ```bash
 ./ac-self-hosted.sh -n "spacetech" up
 ```
 
-On complete, refresh your browser and login to appcircle with your account. You should see new git providers on repository connection page. :tada:
+On complete, refresh your browser and login to Appcircle with your account. You should see new git providers on repository connection page. :tada:
 
 ![](https://cdn.appcircle.io/docs/assets/be-850-sample-enable-both-options.png)

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -11,11 +11,11 @@ Following sections give you detailed information about system requirements, inst
 
 ## Prerequisites
 
-Below are the hardware and OS requirements for self-hosted appcircle installaion.
+Below are the hardware and OS requirements for self-hosted Appcircle installaion.
 
 ### Supported Linux Distributions
 
-Self-hosted appcircle server can only be installed on Linux operating system.
+Self-hosted Appcircle server can only be installed on Linux operating system.
 
 - Ubuntu 20.04 or later
 - Debian 11 or later
@@ -24,7 +24,7 @@ Self-hosted appcircle server can only be installed on Linux operating system.
 
 ### Hardware Requirements
 
-Minimum hardware requirements for self-hosted appcircle can be:
+Minimum hardware requirements for self-hosted Appcircle can be:
 
 - 100GB or more free disk space
 - 4 or more cores CPU
@@ -40,7 +40,7 @@ CPU arhitecture must be AMD or Intel 64-bit arch (`x86_64`).
 
 :::info
 
-If you have enough RAM and a recent CPU, performance of appcircle server can be limited by hard drive seek times. So, having a fast drive like a solid state drive (SSD) improves runtime.
+If you have enough RAM and a recent CPU, performance of Appcircle server can be limited by hard drive seek times. So, having a fast drive like a solid state drive (SSD) improves runtime.
 
 :::
 
@@ -62,7 +62,7 @@ For production environments, **recommended** hardware requirements are
 
 #### Swap
 
-Using **swap** file lets self-hosted appcircle server exceed the size of available physical memory. On memory pressure system will go on its operations with minimal degradation, when SSD used as hardware.
+Using **swap** file lets self-hosted Appcircle server exceed the size of available physical memory. On memory pressure system will go on its operations with minimal degradation, when SSD used as hardware.
 
 So, we are recommending **swap** file usage on Linux.
 
@@ -87,13 +87,13 @@ You need to have the following tools installed on your system:
 - curl
 - unzip
 
-Download the latest self-hosted appcircle package.
+Download the latest self-hosted Appcircle package.
 
 ```bash
 curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.2.2.zip
 ```
 
-Extract self-hosted appcircle package into folder.
+Extract self-hosted Appcircle package into folder.
 
 ```bash
 unzip -o -u appcircle-server-linux-x64-3.2.2.zip -d appcircle-server
@@ -136,7 +136,7 @@ Make sure the script was executed without any error. Script will print installed
 
 :::info
 
-Docker engine is one of our major dependencies. So, its version is also important for appcircle server runtime.
+Docker engine is one of our major dependencies. So, its version is also important for Appcircle server runtime.
 
 Older docker versions may be incompatible for our operations. Docker versions above `20.10.11` should be preferred to eliminate any compatibility issues.
 
@@ -148,7 +148,7 @@ If your linux distribution has an out of date docker version, please update dist
 
 #### Docker Engine Installation
 
-Self-hosted appcircle server is only compatible with official installation methods listed in [here](https://docs.docker.com/engine/install/).
+Self-hosted Appcircle server is only compatible with official installation methods listed in [here](https://docs.docker.com/engine/install/).
 
 On some Linux distributions you can select docker engine at setup stage, but it's not recommended since some distributions have unofficial installation methods.
 
@@ -156,13 +156,13 @@ For instance, when you select docker engine at setup on Ubuntu installation, Ubu
 
 In this case, you should not include docker engine to Ubuntu installation. If you want, you can install docker engine later with official [installation](https://docs.docker.com/engine/install/ubuntu/) steps.
 
-Or, as a better choice, you can leave docker engine installation to self-hosted appcircle server installation script since we have automated installation for Debian derivatives which include `apt` package manager.
+Or, as a better choice, you can leave docker engine installation to self-hosted Appcircle server installation script since we have automated installation for Debian derivatives which include `apt` package manager.
 
 :::
 
 :::info
 
-Self-hosted appcircle server is only compatible with [docker compose V2](https://docs.docker.com/compose/compose-v2/) and the new `docker compose` command.
+Self-hosted Appcircle server is only compatible with [docker compose V2](https://docs.docker.com/compose/compose-v2/) and the new `docker compose` command.
 
 The new compose V2, which supports the compose command as part of the docker CLI, is available with latest docker versions.
 
@@ -178,7 +178,7 @@ If `docker-compose-plugin` is missing in your system, follow its [docs](https://
 
 ### 3. Configure
 
-First we need to find a name to our self-hosted appcircle installation. It will be the unique project name.
+First we need to find a name to our self-hosted Appcircle installation. It will be the unique project name.
 
 ```bash
 ./ac-self-hosted.sh -n "${YOUR_PROJECT}" export
@@ -334,7 +334,7 @@ Same as in cloud, it must be compatible with Appcircle password policy;
 
 #### Troubleshooting
 
-If `keycloak.initialPassword` value is not compatible with password policy, you will get below error on service start while [running appcircle server](./installation.md#5-run-server).
+If `keycloak.initialPassword` value is not compatible with password policy, you will get below error on service start while [running Appcircle server](./installation.md#5-run-server).
 
 ```txt
 service "keycloak_migration" didn't completed successfully: exit 1
@@ -441,11 +441,11 @@ Below is an example DNS configuration that is compatible with our sample scenari
 
 ![](https://cdn.appcircle.io/docs/assets/be-845-dns-settings.png)
 
-If you have a dedicated DNS, adding subdomains will be enough to run self-hosted appcircle server in an easy and quick way.
+If you have a dedicated DNS, adding subdomains will be enough to run self-hosted Appcircle server in an easy and quick way.
 
 You can also make DNS settings later, when you complete all configuration and testing.
 
-Until you're satisfied with your setup, you can use `/etc/hosts` file for both self-hosted appcircle server and connected clients. You can run whole system, test all functionality and your configuration with using the `/etc/hosts` file.
+Until you're satisfied with your setup, you can use `/etc/hosts` file for both self-hosted Appcircle server and connected clients. You can run whole system, test all functionality and your configuration with using the `/etc/hosts` file.
 
 Following section will give you the details for this use case.
 
@@ -461,7 +461,7 @@ Entries in the hosts file have the following format:
 Address  HostName
 ```
 
-On self-hosted appcircle server, you should add below entries to the `/etc/hosts` file.
+On self-hosted Appcircle server, you should add below entries to the `/etc/hosts` file.
 
 ```txt
 0.0.0.0  api.appcircle.spacetech.com
@@ -474,9 +474,9 @@ On self-hosted appcircle server, you should add below entries to the `/etc/hosts
 0.0.0.0  store.spacetech.com
 ```
 
-For clients that will connect to self-hosted appcircle server, either self-hosted runners or end-users using their browsers for web UI, should add external IP of the server to their `/etc/hosts` files. External IP is the address of self-hosted appcircle server that other hosts in the network can reach to server using that address.
+For clients that will connect to self-hosted Appcircle server, either self-hosted runners or end-users using their browsers for web UI, should add external IP of the server to their `/etc/hosts` files. External IP is the address of self-hosted Appcircle server that other hosts in the network can reach to server using that address.
 
-You can get external IP of self-hosted appcircle server with below command.
+You can get external IP of self-hosted Appcircle server with below command.
 
 ```bash
 hostname -I | awk '{print $1}'
@@ -497,13 +497,13 @@ Other clients that connect to the server should add below entries to their `/etc
 35.241.181.2  store.spacetech.com
 ```
 
-With this network setup, you can run and test both self-hosted appcircle server and connected self-hosted runners with all functionality.
+With this network setup, you can run and test both self-hosted Appcircle server and connected self-hosted runners with all functionality.
 
 ### 5. Run Server
 
 Appcircle server's modules are run on Docker Engine as a container application on your system. All containers are run using a `compose.yaml` file which is generated after `ac-self-hosted.sh` is executed successfully explained in above steps.
 
-`projects/${YOUR_PROJECT}/export` path will have all exported envrionment for self-hosted appcircle services along with `compose.yaml`.
+`projects/${YOUR_PROJECT}/export` path will have all exported envrionment for self-hosted Appcircle services along with `compose.yaml`.
 
 ```text
 projects/
@@ -537,7 +537,7 @@ projects/
     └── user-secret
 ```
 
-Run appcircle server services.
+Run Appcircle server services.
 
 ```bash
 ./ac-self-hosted.sh -n "spacetech" up
@@ -547,9 +547,9 @@ Run appcircle server services.
 
 #### Artifact Registry Credentials: Cred.json
 
-Before we run self-hosted appcircle, we need to set artifact registry credentials. Using credentials JSON key file, we will pull docker images for appcircle server services.
+Before we run self-hosted appcircle, we need to set artifact registry credentials. Using credentials JSON key file, we will pull docker images for Appcircle server services.
 
-Although it's not required immediately at configuration steps, it's required while we're starting appcircle server. Otherwise it can not pull docker images from our artifact registry.
+Although it's not required immediately at configuration steps, it's required while we're starting Appcircle server. Otherwise it can not pull docker images from our artifact registry.
 
 For this reason, it's a part of the configuration. `ac-self-hosted.sh` bash script configures docker engine with appropriate credentials. If you don't have the key file, bash script gives error with a detailed message about the requirement.
 
@@ -557,7 +557,7 @@ When you buy an enterprise license for self-hosted appcircle, you will get a cre
 
 You've got `space-tech-cred.json` key file and dowloaded it into `~/Downloads` folder.
 
-First you need to copy that key file into self-hosted appcircle root directory.
+First you need to copy that key file into self-hosted Appcircle root directory.
 
 ```bash
 cp ~/Downloads/space-tech-cred.json cred.json
@@ -620,9 +620,9 @@ If everything is okay, then you should see service statuses as "running", "runni
 
 All secret data, including the API keys, signing identities, environment variables, and secrets are stored in an HashiCorp Vault. OAuth tokens and SSH keys, used in build pipeline, are also stored securely in HashiCorp Vault.
 
-Vault is a tool for securely accessing secrets. It's an important and required service for whole self-hosted appcircle server. If it's status is `unhealthy`, secrets will be inaccessible and most CI/CD functions won't work properly.
+Vault is a tool for securely accessing secrets. It's an important and required service for whole self-hosted Appcircle server. If it's status is `unhealthy`, secrets will be inaccessible and most CI/CD functions won't work properly.
 
-For this reason, **before starting to use self-hosted appcircle server** within your organization, make sure you check **vault service** status in container list above. Its **status must be `healthy`**.
+For this reason, **before starting to use self-hosted Appcircle server** within your organization, make sure you check **vault service** status in container list above. Its **status must be `healthy`**.
 
 While you're working on configuration back and forth, it's status may become `unhealthy` in some way.
 
@@ -638,9 +638,9 @@ Then make a new export and start services. Refer to [reset configuration](./inst
 
 :::info
 
-Self-hosted appcircle server uses some ports for communication.
+Self-hosted Appcircle server uses some ports for communication.
 
-Below ports must be unused on system and dedicated to only appcircle server usage.
+Below ports must be unused on system and dedicated to only Appcircle server usage.
 
 - `80`
 - `443`
@@ -749,7 +749,7 @@ image:
 ./ac-self-hosted.sh -n "spacetech" export
 ```
 
-- Run appcircle server services.
+- Run Appcircle server services.
 
 ```bash
 /ac-self-hosted.sh -n "spacetech" up
@@ -761,7 +761,7 @@ Open your browser and go to URL `http://my.appcircle.spacetech.com`. You should 
 
 ![](https://cdn.appcircle.io/docs/assets/self-hosted-appcircle-login-page.png)
 
-Login to self-hosted appcircle with `initialUsername` and `initialPassword` that we have configured in above steps. For our example, user name is `admin@spacetech.com`.
+Login to self-hosted Appcircle with `initialUsername` and `initialPassword` that we have configured in above steps. For our example, user name is `admin@spacetech.com`.
 
 ![](https://cdn.appcircle.io/docs/assets/self-hosted-appcircle-dashboard-page.png)
 
@@ -771,7 +771,7 @@ You can also login to enterprise app store with configured custom URL `store.spa
 
 :::info
 
-Although you can run export multiple times with different project names, you can run only one of them as an appcircle server instance.
+Although you can run export multiple times with different project names, you can run only one of them as an Appcircle server instance.
 
 With default installation steps, reserved ports are the same for all exports. For this reason, when you run `docker compose up -d` first instance will reserve open ports to itself. And later `docker compose up -d` commands for other projects will get errors like "port is already allocated".
 
@@ -779,7 +779,7 @@ With default installation steps, reserved ports are the same for all exports. Fo
 
 :::info
 
-For now, self-hosted appcircle server is a single node solution. You can not scale it by adding more nodes with other bare-metals or VMs.
+For now, self-hosted Appcircle server is a single node solution. You can not scale it by adding more nodes with other bare-metals or VMs.
 
 Because it has a self-contained architecture with all its data side-by-side its docker services. Every node can only use its internal volumes and data on host.
 
@@ -789,9 +789,9 @@ Because it has a self-contained architecture with all its data side-by-side its 
 
 If you have made a mistake at installation steps, especially at configuration, you can reconfigure your server after installation.
 
-All configuration updates requires appcircle server restart. So resetting configuration should start with stopping appcircle server.
+All configuration updates requires Appcircle server restart. So resetting configuration should start with stopping Appcircle server.
 
-Stop appcircle server services.
+Stop Appcircle server services.
 
 ```bash
 ./ac-self-hosted.sh -n "spacetech" down
@@ -809,13 +809,13 @@ Its response should be something like below.
 
 :::caution
 
-Some configuration changes may require data cleanup with extra steps which means data loss if you use appcircle server for some time.
+Some configuration changes may require data cleanup with extra steps which means data loss if you use Appcircle server for some time.
 
 For example, you can add other git providers with above steps any time you want without any data loss. But changing `external.scheme` from "http" to "https" or changing `smtpServer.*` settings requires docker volume prune which results with data cleanup.
 
 So, we suggest you to be sure with your configuration before using it in production environment. You can try different settings back and forth until you're satisfied.
 
-To begin reconfiguration with data cleanup, use below command while stopping appcircle server.
+To begin reconfiguration with data cleanup, use below command while stopping Appcircle server.
 
 ```bash
 /ac-self-hosted.sh -n "spacetech" reset
@@ -841,7 +841,7 @@ For our example scenario, root directory is `appcircle-server` as seen [here](./
 
 Now you are ready to restart self-hosted appcircle.
 
-Run appcircle server services.
+Run Appcircle server services.
 
 ```bash
 /ac-self-hosted.sh -n "spacetech" up
@@ -863,7 +863,7 @@ By default, self-hosted runner package has pre-configured `ASPNETCORE_BASE_API_U
 
 - `https://api.appcircle.io/build/v1`
 
-:point_up: You need to change its value with your self-hosted appcircle server's API URL.
+:point_up: You need to change its value with your self-hosted Appcircle server's API URL.
 
 Assuming our sample scenario explained above, its value should be
 
@@ -877,6 +877,6 @@ Please note that, you should do this before [register](./self-hosted-runner/inst
 
 :::
 
-Considering system performance, it will be good to install self-hosted runners to other machines. Self-hosted appcircle server should run on a dedicated machine itself.
+Considering system performance, it will be good to install self-hosted runners to other machines. Self-hosted Appcircle server should run on a dedicated machine itself.
 
-You can install any number of runners regarding to your needs and connect them to self-hosted appcircle server.
+You can install any number of runners regarding to your needs and connect them to self-hosted Appcircle server.

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -240,17 +240,6 @@ smtpServer:
   ssl:
   auth:
   starttls:
-recaptcha:
-  requirement: DISABLED # REQUIRED vs DISABLED
-bruteForce:
-  bruteForceProtected: 'true'
-  permanentLockout: 'false'
-  maxFailureWaitSeconds: '900'
-  minimumQuickLoginWaitSeconds: '60'
-  waitIncrementSeconds: '60'
-  quickLoginCheckMilliSeconds: '1000'
-  maxDeltaTimeSeconds: '43200'
-  failureFactor: '30'
 keycloak:
   initialUsername: admin@example.com
   enabledRegistration: true
@@ -289,17 +278,6 @@ smtpServer:
   ssl: 'false'
   auth: 'true'
   starttls: 'true'
-recaptcha:
-  requirement: DISABLED # REQUIRED vs DISABLED
-bruteForce:
-  bruteForceProtected: 'true'
-  permanentLockout: 'false'
-  maxFailureWaitSeconds: '900'
-  minimumQuickLoginWaitSeconds: '60'
-  waitIncrementSeconds: '60'
-  quickLoginCheckMilliSeconds: '1000'
-  maxDeltaTimeSeconds: '43200'
-  failureFactor: '30'
 keycloak:
   initialUsername: admin@spacetech.com
   enabledRegistration: true

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -427,11 +427,21 @@ Until you're satisfied with your setup, you can use `/etc/hosts` file for both s
 
 Following section will give you the details for this use case.
 
-#### Using `/etc/hosts` for DNS Settings
+#### Using `hosts` file for DNS Settings
 
 The hosts file contains the Internet Protocol (IP) host names and addresses for the local host and other hosts in the network. This file is used to resolve a name into an address (that is, to translate a host name into its IP).
 
 So, you can use hosts file like DNS by adding all required subdomains with their mapped IP address.
+
+:::info
+
+Hosts file is located at :
+
+`/etc/hosts` on Linux and MacOS
+
+`C:\Windows\System32\drivers\etc\hosts` on Windows
+
+:::
 
 Entries in the hosts file have the following format:
 

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -435,11 +435,10 @@ So, you can use hosts file like DNS by adding all required subdomains with their
 
 :::info
 
-Hosts file is located at :
+Hosts file is located at:
 
-`/etc/hosts` on Linux and MacOS
-
-`C:\Windows\System32\drivers\etc\hosts` on Windows
+- `/etc/hosts` on Linux and MacOS
+- `C:\Windows\System32\drivers\etc\hosts` on Windows
 
 :::
 

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -11,7 +11,7 @@ Following sections give you detailed information about system requirements, inst
 
 ## Prerequisites
 
-Below are the hardware and OS requirements for self-hosted Appcircle installaion.
+Below are the hardware and OS requirements for self-hosted Appcircle installation.
 
 ### Supported Linux Distributions
 
@@ -34,7 +34,7 @@ Minimum hardware requirements for self-hosted Appcircle can be:
 
 :::caution
 
-CPU arhitecture must be AMD or Intel 64-bit arch (`x86_64`).
+CPU architecture must be AMD or Intel 64-bit arch (`x86_64`).
 
 :::
 
@@ -503,7 +503,7 @@ With this network setup, you can run and test both self-hosted Appcircle server 
 
 Appcircle server's modules are run on Docker Engine as a container application on your system. All containers are run using a `compose.yaml` file which is generated after `ac-self-hosted.sh` is executed successfully explained in above steps.
 
-`projects/${YOUR_PROJECT}/export` path will have all exported envrionment for self-hosted Appcircle services along with `compose.yaml`.
+`projects/${YOUR_PROJECT}/export` path will have all exported environment for self-hosted Appcircle services along with `compose.yaml`.
 
 ```text
 projects/
@@ -555,7 +555,7 @@ For this reason, it's a part of the configuration. `ac-self-hosted.sh` bash scri
 
 When you buy an enterprise license for self-hosted appcircle, you will get a credentials JSON key file which enables you to login our artifact registry. For example, assume our fictive company is Space Tech.
 
-You've got `space-tech-cred.json` key file and dowloaded it into `~/Downloads` folder.
+You've got `space-tech-cred.json` key file and downloaded it into `~/Downloads` folder.
 
 First you need to copy that key file into self-hosted Appcircle root directory.
 

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -228,7 +228,7 @@ If you want a secret used from `global.yaml`, then it should not be in `user-sec
 environment: Production
 enableErrorHandling: 'true'
 external:
-  scheme: https
+  scheme: http
   mainDomain: '.example.com'
 
 smtpServer:

--- a/docs/self-hosted-appcircle/overview.md
+++ b/docs/self-hosted-appcircle/overview.md
@@ -9,7 +9,7 @@ Self-hosted Appcircle enables you to use your own systems and infrastructure for
 
 By this way, you can build and test your apps on your choice of architectures. You have full control over the build environment. You can also customize your Appcircle installation with various options.
 
-When we look at self-hosted Appcircle deployment as a whole, we will see below arhitecture in execution.
+When we look at self-hosted Appcircle deployment as a whole, we will see below architecture in execution.
 
 ![](https://cdn.appcircle.io/docs/assets/self-hosted_appcircle_v5.png)
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/custom-certificates.md
@@ -7,7 +7,7 @@ sidebar_position: 8
 
 # Overview
 
-If you're using self-signed certificates in your environment, the same certificates must also be added to runners. It can be your self-hosted appcircle server or your own git repositories.
+If you're using self-signed certificates in your environment, the same certificates must also be added to runners. It can be your self-hosted Appcircle server or your own git repositories.
 
 If you don't add and trust those self-signed certificates, runner will most probably get SSL connection errors while trying to access those resources.
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/manage-pools.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/manage-pools.md
@@ -37,7 +37,7 @@ For example, if your pool has only android tools configured in its runners, you 
 
 You can not define or select specific self-hosted runner in a pool. When a build job enters queue, it will be selected by any of the runner in that pool. So, as a best practice, try to organize your pool homogeneously.
 
-Pools should have runners which have similar tools and capabilities. Machine architecture (arm64, x86_64) can also be taken into account when orgnizing self-hosted pools.
+Pools should have runners which have similar tools and capabilities. Machine architecture (arm64, x86_64) can also be taken into account when organizing self-hosted pools.
 
 :::
 
@@ -49,7 +49,7 @@ Changing runner pool doesn't affect current running builds on pool. It will affe
 
 ### Delete Self-hosted Pool
 
-Pool removal is managed automatically while removing or moving runner. If you remove a self-hosted runner and its pool doesn't have any other runners in that pool, then empty pool is deleted automatically and you won't see it in self-hosted runners list or build profile config tab. Same behaviour happens when you move a self-hosted runner from one pool to another.
+Pool removal is managed automatically while removing or moving runner. If you remove a self-hosted runner and its pool doesn't have any other runners in that pool, then empty pool is deleted automatically and you won't see it in self-hosted runners list or build profile config tab. Same behavior happens when you move a self-hosted runner from one pool to another.
 
 If you want to remove pool manually or remove group of runners with pool removal, click on pool name at "Self-hosted Runners" list and use "Delete" button at the bottom of pool details.
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/manage-runners.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/manage-runners.md
@@ -95,7 +95,7 @@ You can add more Xcode versions side-by-side or more up-to-date Xcode any time a
 ./ac-runner xcode -v ${Xcode Version}
 ```
 
-Xcode version argument is similar to xcode argument on [installation](../self-hosted-runner/installation.md#3-configure). You can give one or more versions comma-seperated.
+Xcode version argument is similar to xcode argument on [installation](../self-hosted-runner/installation.md#3-configure). You can give one or more versions comma-separated.
 
 For example, below command will install Xcode 13.1.x:
 

--- a/docs/self-hosted-appcircle/ssl-configuration.md
+++ b/docs/self-hosted-appcircle/ssl-configuration.md
@@ -199,7 +199,7 @@ You should see "Connection Secure" icon in browser's address bar which shows suc
 
 By default, when you enable HTTPS for `external.scheme`, NGINX listens for unencrypted HTTP traffic on port 80 but redirects them as HTTPS with 301 response code automatically.
 
-You don't need to do any manuel configuration to redirect HTTP requests to HTTPS.
+You don't need to do any manual configuration to redirect HTTP requests to HTTPS.
 
 :::
 
@@ -243,7 +243,7 @@ storeWeb:
 
 When you use wildcard certificate for main domain, you don't need to create an extra certificate for enterprise app store domain.
 
-Although your wildcard certficate does not include "Store Prefix", on self-hosted Appcircle server installations "Store Prefix" is not used actively since there is only one organization.
+Although your wildcard certificate does not include "Store Prefix", on self-hosted Appcircle server installations "Store Prefix" is not used actively since there is only one organization.
 
 Prefixed web requests will always be redirected to default store subdomain. And store subdomain is covered by your wildcard certificate.
 

--- a/docs/self-hosted-appcircle/ssl-configuration.md
+++ b/docs/self-hosted-appcircle/ssl-configuration.md
@@ -15,13 +15,13 @@ So, in this section we will document all the details about configuring HTTPS wit
 
 :::caution
 
-Self-hosted appcircle server does not support using a proxy, load balancer or some other external device to terminate SSL. You should do it inside appcircle instance with configuration told in below sections.
+Self-hosted Appcircle server does not support using a proxy, load balancer or some other external device to terminate SSL. You should do it inside Appcircle instance with configuration told in below sections.
 
 :::
 
 :::info
 
-For now, self-hosted appcircle server does not have Let’s Encrypt integration or an automated way of renewing certificates.
+For now, self-hosted Appcircle server does not have Let’s Encrypt integration or an automated way of renewing certificates.
 
 You should manage certificates from configuration file manually and renew them with same method when expired.
 
@@ -48,7 +48,7 @@ You can see an example project configuration from [here](installation.md#3-confi
 
 :::caution
 
-Changing `external.scheme` from `http` to `https` or from `https` to `http` after using appcircle server some time, requires configuration reset which results with data cleanup.
+Changing `external.scheme` from `http` to `https` or from `https` to `http` after using Appcircle server some time, requires configuration reset which results with data cleanup.
 
 So, we suggest you to be sure with your configuration before using it in production environment.
 
@@ -97,7 +97,7 @@ Refer to [installation](./installation.md#3-configure) docs for details of `user
 
 :::caution
 
-For now, self-hosted appcircle does not support usage of password protected private keys.
+For now, self-hosted Appcircle does not support usage of password protected private keys.
 
 :::
 
@@ -243,7 +243,7 @@ storeWeb:
 
 When you use wildcard certificate for main domain, you don't need to create an extra certificate for enterprise app store domain.
 
-Although your wildcard certficate does not include "Store Prefix", on self-hosted appcircle server installations "Store Prefix" is not used actively since there is only one organization.
+Although your wildcard certficate does not include "Store Prefix", on self-hosted Appcircle server installations "Store Prefix" is not used actively since there is only one organization.
 
 Prefixed web requests will always be redirected to default store subdomain. And store subdomain is covered by your wildcard certificate.
 
@@ -311,7 +311,7 @@ You should use the full certificate chain for `publicKey` similar to main domain
 
 :::caution
 
-For now, self-hosted appcircle does not support usage of password protected private keys for Enterprise App Store custom domains.
+For now, self-hosted Appcircle does not support usage of password protected private keys for Enterprise App Store custom domains.
 
 :::
 

--- a/docs/self-hosted-appcircle/ssl-configuration.md
+++ b/docs/self-hosted-appcircle/ssl-configuration.md
@@ -27,6 +27,16 @@ You should manage certificates from configuration file manually and renew them w
 
 :::
 
+:::info
+
+If your cert format `PKCS#7` (known as p7b or p7c) , you can convert it to pem format with openssl. See the example command below.
+
+```bash
+$ openssl pkcs7 -print_certs -in cert.p7b -out cert.pem
+```
+
+:::
+
 ## Configure HTTPS
 
 First of all, you need to set `external.scheme` as `https` at `global.yaml` to enable HTTPS for all [subdomains](./installation.md#4-dns-settings).

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 
 As in cloud, we're releasing regular updates for self-hosted Appcircle server. You should keep your instance up-to-date in order to get latest features, bug fixes and improvements.
 
-When a new version of self-hosted appcirle is released, you can update with below steps.
+When a new version of self-hosted Appcircle is released, you can update with below steps.
 
 :::info
 

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 # Overview
 
-As in cloud, we're releasing regular updates for self-hosted appcircle server. You should keep your instance up-to-date in order to get latest features, bug fixes and improvements.
+As in cloud, we're releasing regular updates for self-hosted Appcircle server. You should keep your instance up-to-date in order to get latest features, bug fixes and improvements.
 
 When a new version of self-hosted appcirle is released, you can update with below steps.
 
@@ -21,7 +21,7 @@ When you're in trouble with update, it will be useful to review details and warn
 
 :::info
 
-Below steps does not affect or destroy your data. Update process keeps your data and schema compatible with latest self-hosted appcircle server by using incremental migrations all handled automatically.
+Below steps does not affect or destroy your data. Update process keeps your data and schema compatible with latest self-hosted Appcircle server by using incremental migrations all handled automatically.
 
 :::
 
@@ -43,13 +43,13 @@ Also, note that you'll need to have Docker Compose version 2.14.1 or later insta
 
 ### 1. Download Latest
 
-Download the latest self-hosted appcircle package.
+Download the latest self-hosted Appcircle package.
 
 ```bash
 curl -O -L https://cdn.appcircle.io/self-hosted/appcircle/appcircle-server-linux-x64-3.2.2.zip
 ```
 
-Extract self-hosted appcircle package into folder.
+Extract self-hosted Appcircle package into folder.
 
 ```bash
 unzip -o -u appcircle-server-linux-x64-3.2.2.zip -d appcircle-server
@@ -65,7 +65,7 @@ For other details and troubleshooting, you can refer to [download](./installatio
 
 ### 2. Update Packages
 
-Although it's rare, update may have new packages or package updates. Those are the tools that self-hosted appcircle depends on. So they should be kept up-to-date same as appcircle server.
+Although it's rare, update may have new packages or package updates. Those are the tools that self-hosted Appcircle depends on. So they should be kept up-to-date same as Appcircle server.
 
 :::caution
 
@@ -116,7 +116,7 @@ For other details and troubleshooting, you can refer to [configuration](./instal
 
 :::info
 
-Although it's rare, self-hosted appcircle may have a new service with its dedicated subdomain.
+Although it's rare, self-hosted Appcircle may have a new service with its dedicated subdomain.
 
 If it was announced in release notes, you need to add new subdomain to your DNS server.
 
@@ -126,7 +126,7 @@ All process is same as in installation, so refer to [DNS settings](./installatio
 
 ### 4. Update Images
 
-In order to get docker image updates for appcircle server services, we need to pull them from remote artifact repository.
+In order to get docker image updates for Appcircle server services, we need to pull them from remote artifact repository.
 
 To activate image updates, first stop all running docker containers.
 
@@ -160,7 +160,7 @@ You may also print the image hashes and script's version by using the below comm
 
 :::caution
 
-Please keep in mind that, restarting docker containers will stop all services until all started again. So, it will take some time and during that duration self-hosted appcircle server will be unreachable.
+Please keep in mind that, restarting docker containers will stop all services until all started again. So, it will take some time and during that duration self-hosted Appcircle server will be unreachable.
 
 For this reason, you may prefer to execute this step on an idle time in order to minimize its negative effects on your users.
 
@@ -180,9 +180,9 @@ But if you want or need to reset your data for some reason, you can follow [rese
 
 :::info
 
-Although it's rare, self-hosted appcircle may require also self-hosted runner update. Because on some cases, it may bring some breaking changes for older runners.
+Although it's rare, self-hosted Appcircle may require also self-hosted runner update. Because on some cases, it may bring some breaking changes for older runners.
 
-If it's required, it will be announced in self-hosted appcircle release notes with minimum supported runner version.
+If it's required, it will be announced in self-hosted Appcircle release notes with minimum supported runner version.
 
 In order to update your self-hosted runners, refer to [update self-hosted runner](./self-hosted-runner/update.md) section in docs.
 


### PR DESCRIPTION
- Some spells fixed
- "appcircle" words uppercased
- Removed unused settings from example yaml
- Added hosts file location for windows, macOS and linux
- Added info about converting pkcs formatted certs to pem format