### PR TITLE
#BE-1315 Add OpenJDK 17

### DIFF
--- a/docs/environment-variables/appcircle-specific-environment-variables.md
+++ b/docs/environment-variables/appcircle-specific-environment-variables.md
@@ -74,6 +74,7 @@ For more information on the inputs of the steps and how the variables in the fol
 | AC\_ANDROID\_APP\_ANALYSIS\_PATH | Location of the app analyzer JSON file   |
 | JAVA\_HOME\_8\_X64               | OpenJDK 8 Location                       |
 | JAVA\_HOME\_11\_X64              | OpenJDK 11 Location                      |
+| JAVA\_HOME\_17\_X64              | OpenJDK 17 Location                      |
 | AC\_BUILD\_NUMBER\_SOURCE        | Build Number Source for Versioning       |
 | AC\_ANDROID\_BUILD\_NUMBER       | Build Number for Versioning              |
 | AC\_BUILD\_OFFSET                | Build Number Offset for Versioning       |

--- a/docs/integrations/working-with-custom-scripts/custom-script-samples.md
+++ b/docs/integrations/working-with-custom-scripts/custom-script-samples.md
@@ -11,17 +11,19 @@ import NarrowImage from '@site/src/components/NarrowImage';
 
 ### Changing JAVA version
 
-If you want to change the JAVA version for your Android project, you can achieve this by changing the JAVA_HOME environment variable. Appcircle currently has OpenJDK 11(default) and OpenJDK 8. You can use the below custom script before your build step for this task.
+If you want to change the JAVA version for your Android project, you can achieve this by changing the JAVA_HOME environment variable. Appcircle currently has OpenJDK 11(default), OpenJDK 8 and OpenJDK 17. You can use the below custom script before your build step for this task.
 
-Appcirle Android build uses OpenJDK 11 as a default. Build machines also have OpenJDK 8 as well. You can use the below custom script to change your JAVA_HOME environment variable.
+Appcircle Android build uses OpenJDK 11 as a default. Build machines also have OpenJDK 8 and OpenJDK 17 as well. You can use the below custom script to change your JAVA_HOME environment variable.
 
 ```bash
-echo "Default JAVA "$JAVA_HOME
-echo "OpenJDK 8 "$JAVA_HOME_8_X64
-echo "OpenJDK 11 "$JAVA_HOME_11_X64
+echo "Default JAVA" $JAVA_HOME
 
-# Change JAVA_HOME to OPENJDK 8
-echo "JAVA_HOME=$JAVA_HOME_8_X64" >> $AC_ENV_FILE_PATH
+echo "OpenJDK 8" $JAVA_HOME_8_X64
+echo "OpenJDK 11" $JAVA_HOME_11_X64
+echo "OpenJDK 17" $JAVA_HOME_17_X64
+
+# Change JAVA_HOME to OPENJDK 17
+echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $AC_ENV_FILE_PATH
 ```
 
 Create a custom script like above and put it **above** your Android build step.

--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -80,7 +80,7 @@ From now on, you will follow same installation steps seen below as other environ
 
 Appcircle provides ready-to-use macOS VM image especially for enterprise installations. It can be run on macOS Monterey or Ventura `arm64` host.
 
-See details in [here](https://cdn.appcircle.io/docs/assets/how-to-operate-macos-vm-d1fdd67.pdf).
+See details in [here](https://cdn.appcircle.io/docs/assets/how-to-operate-macos-vm-c6b70ab.pdf).
 
 :::
 


### PR DESCRIPTION
- Add OpenJDK 17 to available JDK list
- Update "Changing JAVA version" w/ 17
- Add `JAVA_HOME_17_X64` to env vars
___
- Bump macOS VM docs version to `macOS_230606`
