### PR TITLE
#BE-1319 Removed required tools from install section

### DIFF
--- a/docs/self-hosted-appcircle/installation-podman.md
+++ b/docs/self-hosted-appcircle/installation-podman.md
@@ -239,6 +239,11 @@ sudo cp /usr/share/containers/containers.conf /etc/containers/containers.conf
 ```
 
 - Edit the /etc/containers/containers.conf file.
+
+```bash
+sudo vim /etc/containers/container.conf
+```
+
 - Add the following content to the [network] section:
 
 ```bash
@@ -251,6 +256,68 @@ network_backend="netavark"
 
 :::caution
 If you skip the step about podman network stack above, you will encounter network related issues. Please make sure you have completed this step.
+:::
+
+#### Change the Podman Data Location
+
+In certain scenarios, you may encounter situations where the available free space on the root directory (`/`) is limited. However, you might have ample free space in a different directory, such as `$HOME` or `/opt`.
+
+In such cases, you can modify the Podman data location path to utilize the available space in the desired directory.
+
+These are the steps to change podman data location path:
+
+:::caution
+If you have selinux enabled, you should disable it temporarily before changing podman data location.
+
+```bash
+sudo setenforce 0
+```
+
+:::
+
+:::caution
+Podman data path may vary according to users.
+
+- If you will use podman with the root user, the data path is `/var/lib/containers`.
+- If you will use podman with regular user, the data path is `$HOME/.local/share/containers`.
+
+Please be sure about your podman data path.
+
+The commands below are shown for the root user. Please change it according to your data path.
+:::
+
+- Stop the podman service.
+
+```bash
+sudo systemctl stop podman
+```
+
+- Move the existing Podman data directory to the new location.
+
+```bash
+sudo mv /var/lib/containers $HOME/podman
+```
+
+- Create a softlink from default location to the new location.
+
+```bash
+sudo ln -s $HOME/podman /var/lib/containers
+```
+
+- Restart the podman service.
+
+```bash
+sudo systemctl start podman
+```
+
+:::caution
+
+If you disabled selinux and want to enable it again, you can run the following command.
+
+```bash
+sudo setenforce 1
+```
+
 :::
 
 ### 3. Configure

--- a/docs/self-hosted-appcircle/installation-podman.md
+++ b/docs/self-hosted-appcircle/installation-podman.md
@@ -98,9 +98,10 @@ Best option is to use a port forwarding tool like socat. This way you can forwar
 sudo dnf install -y socat
 ```
 
+Save the file below as `port-redirect-80.service` in `/etc/systemd/system/` directory.
+
 ```bash
 [Unit]
-## Save this file as /etc/systemd/system/port-redirect-80.service
 Description=Port Redirect Service - Port 80
 After=network.target
 
@@ -111,9 +112,10 @@ ExecStart=/usr/bin/socat TCP-LISTEN:80,fork,reuseaddr TCP:127.0.0.1:8080
 WantedBy=multi-user.target
 ```
 
+Save the file below as `port-redirect-443.service` in `/etc/systemd/system/` directory.
+
 ```bash
 [Unit]
-## Save this file as /etc/systemd/system/port-redirect-443.service
 Description=Port Redirect Service - Port 443
 After=network.target
 
@@ -123,6 +125,8 @@ ExecStart=/usr/bin/socat TCP-LISTEN:443,fork,reuseaddr TCP:127.0.0.1:8443
 [Install]
 WantedBy=multi-user.target
 ```
+
+Then, one by one, execute the below commands to activate port redirections.
 
 ```bash
 sudo systemctl daemon-reload
@@ -231,7 +235,7 @@ Once the installation is complete, please follow these steps to configure Podman
 - Copy the /usr/share/containers/containers.conf file to /etc/containers/containers.conf.
 
 ```bash
-sudo cp /usr/share/containers/containers.conf /etc/containers/container.conf
+sudo cp /usr/share/containers/containers.conf /etc/containers/containers.conf
 ```
 
 - Edit the /etc/containers/containers.conf file.

--- a/docs/self-hosted-appcircle/installation-podman.md
+++ b/docs/self-hosted-appcircle/installation-podman.md
@@ -181,13 +181,8 @@ cd appcircle-server
 
 ### 2. Packages
 
-You need to have the following tools installed on your system.
+You need to have the following tool(s) installed on your system.
 
-- jq
-- curl
-- openssl
-- gomplate
-- yq
 - podman
 
 The good news is that the ac-self-hosted.sh script installs all the necessary tools if they are not already installed on your system.

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -176,6 +176,38 @@ If `docker-compose-plugin` is missing in your system, follow its [docs](https://
 
 :::
 
+#### Change the Docker Data Location
+
+In certain scenarios, you may encounter situations where the available free space on the root directory (`/`) is limited. However, you might have ample free space in a different directory, such as `$HOME` or `/opt`.
+
+In such cases, you can modify the Docker data location path to utilize the available space in the desired directory.
+
+These are the steps to change docker data location path:
+
+- Stop the docker engine.
+
+```bash
+sudo systemctl stop docker
+```
+
+- Move the existing Docker data directory to the new location.
+
+```bash
+sudo mv /var/lib/docker $HOME/docker
+```
+
+- Create a softlink from default location to the new location.
+
+```bash
+sudo ln -s $HOME/docker /var/lib/docker
+```
+
+- Start the docker engine.
+
+```bash
+sudo systemctl start docker
+```
+
 ### 3. Configure
 
 First we need to find a name to our self-hosted Appcircle installation. It will be the unique project name.

--- a/docs/self-hosted-appcircle/installation.md
+++ b/docs/self-hosted-appcircle/installation.md
@@ -107,13 +107,8 @@ cd appcircle-server
 
 ### 2. Packages
 
-You need to have the following tools installed on your system.
+You need to have the following tool(s) installed on your system.
 
-- jq
-- curl
-- openssl
-- gomplate
-- yq
 - docker
 
 The good news is that the ac-self-hosted.sh script installs all the necessary tools if they are not already installed on your system.


### PR DESCRIPTION
Required tools which is curl, jq, yq, openssl and gomplate has been removed.
Now we are bringing dependencies with the server zip file. So the user don't need to install it. 