### PR TITLE
#BE-1791 Added macOS Runner vm Installation Page

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -80,7 +80,7 @@ From now on, you will follow same installation steps seen below as other environ
 
 Appcircle provides ready-to-use macOS VM image especially for enterprise installations. It can be run on macOS Monterey or Ventura `arm64` host.
 
-See details in [here](https://cdn.appcircle.io/docs/assets/how-to-operate-macos-vm-772ea46.pdf).
+See details in [here](./runner-vm-setup.md).
 
 :::
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -128,8 +128,8 @@ In order to keep free disk space sufficient for build pipelines, we're packaging
 
 You can find more information about the build infrastructure in the documents below:
 
-- [iOS Build Infrastructure](https://docs.appcircle.io/infrastructure/ios-build-infrastructure)
-- [Android Build Infrastructure](https://docs.appcircle.io/infrastructure/android-build-infrastructure)
+- [iOS Build Infrastructure](../../infrastructure/ios-build-infrastructure.md)
+- [Android Build Infrastructure](../../infrastructure/android-build-infrastructure.md)
 
 ## Create Base Images
 
@@ -212,7 +212,7 @@ Edit `appsettings.json` with your favorite editor. (nano, vi etc.)
 
 Runner will register to server defined in `ASPNETCORE_BASE_API_URL` and take build jobs from there.
 
-Create runner access token from appcircle server and register runner to server. See details in [here](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/installation#2-register).
+Create runner access token from appcircle server and register runner to server. See details in [here](../self-hosted-runner/installation.md#2-register).
 
 For example,
 
@@ -344,7 +344,7 @@ touch $HOME/runner1/.stop
 
 Creating `.stop` file prevents creating new instance by `run.sh` on shutdown.
 
-If runner is executing build pipeline, you may prefer waiting completion of the build job. See [stop](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/runner-service#stop) section at self-hosted runner docs. When executing build pipeline completes, runner will be shutdown automatically.
+If runner is executing build pipeline, you may prefer waiting completion of the build job. See [stop](../self-hosted-runner/configure-runner/runner-service.md#stop) section at self-hosted runner docs. When executing build pipeline completes, runner will be shutdown automatically.
 
 On the other hand if you want to stop runner immediately for whatever reason or it's in idle state, you can SSH into runner and run shutdown command.
 
@@ -402,7 +402,7 @@ On some cases, you may need to update to your macOS base images in order to make
 Below are the ones that frequently occur, but not limited to them.
 
 - Your team might use a tool frequently in build pipeline, that's not included in Appcircle macOS image. Installing that tool into the image once will save build time. Your build pipeline will be more efficient and optimized.
-- You may prefer to get iOS and android tool updates by using [self-hosted runner update](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/update) method instead of getting fresh macOS VM image. When you get fresh macOS image you may need to make your custom configurations again.
+- You may prefer to get iOS and android tool updates by using [self-hosted runner update](../self-hosted-runner/update.md) method instead of getting fresh macOS VM image. When you get fresh macOS image you may need to make your custom configurations again.
 - You may need to make persistent proxy configuration for your internal network requirements.
 - You may need to add your corporate's self-signed root CAs to macOS VM image in order to succeed SSL connections.
 
@@ -487,7 +487,7 @@ screen -d -m $HOME/runner2/run.sh vm02
 
 In this case, you need to focus on self-hosted runner issues inside macOS VM (guest).
 
-In order to be able to investigate root cause, you should learn the basics of self-hosted runner. Check our [online docs](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/overview) details.
+In order to be able to investigate root cause, you should learn the basics of self-hosted runner. Check our [online docs](./overview.md) details.
 
 - You can check your macOS guest for possible system issues. (disk space, network connectivity etc.)
 - If you have custom proxy settings on macOS guest, check these settings.

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -1,0 +1,551 @@
+---
+title: Runner Virtual Machine Setup
+metaTitle: Runner Virtual Machine Setup
+metaDescription: Runner Virtual Machine Setup
+sidebar_class_name: hidden
+---
+
+# Self-hosted Runner as MacOS VM Image
+
+Self-hosted runner installation is explained at Appcircle [docs](installation.md) in detail. You can install runner in your self-hosted environment by yourself, following instructions on there.
+
+We're also providing ready-to-use runner VM image that you can download from Appcircle CDN. Especially for enterprise installation, it might be more practical than installing from scratch.
+
+Here are some reasons for choosing VM image for self-hosted runner;
+
+- It's more quick and easy way of deploying runner. Just download VM image and make some minor configurations for your environment.
+- While installing runner, we need several packages from various sources on internet and runner installation requires to be online. Since all iOS and android build pipeline tools are included in VM image, you don't need complex firewall rules while deploying runner.
+- It minimizes effects of strict macOS policies applied to host, especially at enterprise environments. Your runner environment will be same as used in Appcircle cloud.
+- Since we use virtual machine for runner, it provides a clean, isolated instance for every build job. It means, known and more stable runner environment. Your runner won't persist any macOS changes done in build pipeline which can make runner unstable in time.
+- You can install and run only one instance of self-hosted runner on a physical machine. On the other hand, using virtualization infrastructure brings us concurrency. We can run multiple instances of runner on the same host.
+
+## Requirements
+
+In order to use macOS VM, we need to install some dependencies on macOS host.
+
+### 1. Install Homebrew
+
+Script explains what it will do, follow instructions on there.
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+When installation complete, test:
+
+```bash
+brew doctor
+```
+
+```bash
+brew --version
+```
+
+### 2. Install Tart
+
+Tap Appcircle repository and install tart.
+
+```bash
+brew tap appcircleio/cli
+```
+
+```bash
+brew install appcircleio/cli/tart
+```
+
+When installation complete, test:
+
+```bash
+tart --version
+```
+
+Run `tart` to touch initial folders.
+
+```bash
+tart list
+```
+
+Create VMs root folder in tart home.
+
+```bash
+mkdir $HOME/.tart/vms
+```
+
+## Download MacOS VM
+
+Download macOS VM from Appcircle bucket.
+
+```bash
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_230606.tar.gz
+```
+
+If you encounter network interruption, just run the same command again. It should continue download for remaining part. It will result in saving both time and bandwidth.
+
+---
+
+**Note:** You can check the integrity of downloaded file by comparing the MD5 checksum.
+
+```bash
+md5 macOS_230606.tar.gz
+```
+
+After a couple of minutes later you should see the output below.
+
+```bash
+MD5 (macOS_230606.tar.gz) = 6b6bcb5ecb3a45acd48cbc886b6b3817
+```
+
+---
+
+Create folder for VM.
+
+```bash
+mkdir $HOME/.tart/vms/macOS_230606
+```
+
+Extract archive into VMs folder.
+
+```bash
+tar -zxf macOS_230606.tar.gz --directory $HOME/.tart/vms/macOS_230606
+```
+
+It may take a little to complete. Be patient and wait return of command.
+
+You can track progress of extraction by monitoring VM folder size.
+
+```bash
+du -sh $HOME/.tart/vms/macOS_230606
+```
+
+**Note:** This macOS VM image contains the same tools as in the "default m1 pool" in Appcircle Cloud. The only difference is the bundled Xcode versions. It comes with the Xcode versions below:
+
+- `14.3.x`
+- `14.2.x`
+- `14.1.x`
+- `13.4.x`
+
+In order to keep free disk space sufficient for build pipelines, we're packaging the latest and most frequently used Xcode versions. But you can also install other Xcode versions yourself if required.
+
+You can find more information about the build infrastructure in the documents below:
+
+- [iOS Build Infrastructure](https://docs.appcircle.io/infrastructure/ios-build-infrastructure)
+- [Android Build Infrastructure](https://docs.appcircle.io/infrastructure/android-build-infrastructure)
+
+## Create Base Images
+
+Apple's virtualization framework allows us to run up to two macOS VMs on host.
+
+Each runner must register to the self-hosted appcircle server with a unique name and configuration. So we will need two VM base images.
+
+When you list VMs with `tart list`, you should see our extracted VM image in list.
+
+```txt
+Source Name         Size
+local  macOS_230606 167
+```
+
+Create VM image for runner1.
+
+```bash
+tart clone macOS_230606 vm01
+```
+
+Create VM image for runner2.
+
+```bash
+tart clone macOS_230606 vm02
+```
+
+In docker terminology, `vm01` and `vm02` will be our docker images. We will configure them separately, persist our changes and then create containers to execute build pipelines. On every build, fresh containers will be used for both runners.
+
+Start runner1 VM image for configuration.
+
+```bash
+screen -d -m tart run vm01 --no-graphics
+```
+
+SSH login into running macOS VM.
+
+```bash
+ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm01)
+```
+
+---
+
+**Note:** You should use "cicd" as SSH login password.
+
+---
+
+In macOS VM, `/Volumes/agent-disk/appcircle-runner` is the root folder of runner.
+
+```bash
+cd /Volumes/agent-disk/appcircle-runner
+```
+
+So, the following commands will assume that current working directory is `/Volumes/agent-disk/appcircle-runner`.
+
+---
+
+**Note:** Runner logs are kept in `$HOME/appcircle-runner` folder.
+
+---
+
+Stop runner service.
+
+```bash
+./ac-runner service -c stop
+```
+
+Edit `appsettings.json` with your favorite editor. (nano, vi etc.)
+
+```json
+{
+  ...
+  "ASPNETCORE_NOSHUTDOWN": "false",
+  ...
+  "ASPNETCORE_BASE_API_URL": "https://api.test-appcircle.tool.zb/build/v1"
+}
+```
+
+- ASPNETCORE_NOSHUTDOWN: It should be `false`. So, it will shutdown VM when build complete.
+- ASPNETCORE_BASE_API_URL: It should be your self-hosted appcircle server URL.
+
+Runner will register to server defined in `ASPNETCORE_BASE_API_URL` and take build jobs from there.
+
+Create runner access token from appcircle server and register runner to server. See details in [here](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/installation#2-register).
+
+For example,
+
+```bash
+./ac-runner register -t aat_eev4NQdG_7F2jodmMShBFhh_DgabOJSsWSMojX5_lo4 -n runner1 -p macOS_pool
+```
+
+It won't print anything to CLI on success. You can also check its exit value with `echo $?`. It should be `0` on success.
+
+```bash
+./ac-runner service -c start
+```
+
+Now you should see "runner1" in "Build > Self-hosted Runners" list. It may take a couple of seconds to become online.
+
+If "runner1" is online, we can shutdown VM since configuration is done with success.
+
+```bash
+sudo shutdown -h now
+```
+
+Start runner2 image for configuration.
+
+```bash
+screen -d -m tart run vm02 --no-graphics
+```
+
+SSH login into running macOS VM.
+
+```bash
+ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm02)
+```
+
+After login, configuration steps are the same as "runner1". So, we don't need to repeat same commands again.
+
+The only difference should be runner naming. It must be unique. For the second runner, just give a different name. For example, "runner2".
+
+After shutdown, we're ready to run instances from `vm01` and `vm02` base VM images.
+
+At this stage your VM list returned by `tart list` should be like below.
+
+```txt
+Source Name         Size
+local  macOS_230606 167
+local  vm01         130
+local  vm02         130
+```
+
+## Operating MacOS VMs
+
+### Prerequisites
+
+We need to create two seperate folders for two runners. These will be their working directories on runtime.
+
+Create folder for "runner1".
+
+```bash
+mkdir $HOME/runner1
+```
+
+Create folder for "runner2".
+
+```bash
+mkdir $HOME/runner2
+```
+
+We have a simple bash script that will be used to run VM instances in loop.
+
+Download the script into runner folders you created and make script executable.
+
+For "runner1" use below commands.
+
+```bash
+curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run.sh
+chmod u+x $HOME/runner1/run.sh
+```
+
+For "runner2" use below commands.
+
+```bash
+curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run.sh
+chmod u+x $HOME/runner2/run.sh
+```
+
+### Start VM
+
+In order to start "runner1", use below command.
+
+```bash
+screen -d -m $HOME/runner1/run.sh vm01
+```
+
+It will start "runner1" in detached mode and will manage VM lifecycle continuously.
+
+In a couple of minutes, you should see "runner1" as online in self-hosted runners list.
+
+We can also start "runner2" with below command.
+
+```bash
+screen -d -m $HOME/runner2/run.sh vm02
+```
+
+In docker terminology, we're creating container from docker image at this stage. On build complete, runner will be shutdown automatically and `run.sh` will create a fresh one from macOS image. It continuously does the same operation until stopped.
+
+We can see running instances on macOS host with `tart list`.
+
+```txt
+Source Name                                      Size
+local  macOS_230606                              167
+local  vm01                                      130
+local  vm01-4f496549-cfe8-462c-ba55-774f01c03b4f 130
+local  vm02                                      130
+local  vm02-9f1fc62a-f43c-40f3-98d0-523ed9a67042 130
+```
+
+As you can see in list, we have new VMs with long unique name. Those are actually online VMs that we started.
+
+`vm01` and `vm02` are immutable VM images. On the other hand, others are instances created from VM images.
+
+### Stop VM
+
+In order to stop VM, we need to mark runner as stopped and shutdown online runner over SSH.
+
+Touch `.stop` file at runner's working directory.
+
+```bash
+touch $HOME/runner1/.stop
+```
+
+Creating `.stop` file prevents creating new instance by `run.sh` on shutdown.
+
+If runner is executing build pipeline, you may prefer waiting completion of the build job. See [stop](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/runner-service#stop) section at self-hosted runner docs. When executing build pipeline completes, runner will be shutdown automatically.
+
+On the other hand if you want to stop runner immediately for whatever reason or it's in idle state, you can SSH into runner and run shutdown command.
+
+First you need to have to find out online runner's VM name from `tart list`.
+
+```txt
+Source Name                                      Size
+local  macOS_230606                              167
+local  vm01                                      130
+local  vm01-4f496549-cfe8-462c-ba55-774f01c03b4f 130
+local  vm02                                      130
+local  vm02-9f1fc62a-f43c-40f3-98d0-523ed9a67042 130
+```
+
+In above list, "vm01-4f496549-cfe8-462c-ba55-774f01c03b4f" is the name of runner that we will shutdown.
+
+SSH login into that runner.
+
+```bash
+ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm01-4f496549-cfe8-462c-ba55-774f01c03b4f)
+```
+
+---
+
+**Note:** You should use "cicd" as SSH login password.
+
+---
+
+Execute shutdown command.
+
+```bash
+sudo shutdown -h now
+```
+
+Shutdown process may take a couple of seconds.
+
+After shutdown, you won't see anymore instance from `vm01` on `tart list`.
+
+```txt
+Source Name                                      Size
+local  macOS_230606                              167
+local  vm01                                      130
+local  vm02                                      130
+local  vm02-9f1fc62a-f43c-40f3-98d0-523ed9a67042 130
+```
+
+After a couple of minutes later, "runner1" will also become offline at self-hosted runners list.
+
+Steps are also similar for "runner2". You need to touch `.stop` file in its working directory and after getting its VM name from `tart list`, you can shutdown "runner2" over SSH.
+
+## Update Base Images
+
+On some cases, you may need to update to your macOS base images in order to make your changes permanent.
+
+Below are the ones that frequently occur, but not limited to them.
+
+- Your team might use a tool frequently in build pipeline, that's not included in Appcircle macOS image. Installing that tool into the image once will save build time. Your build pipeline will be more efficient and optimized.
+- You may prefer to get iOS and android tool updates by using [self-hosted runner update](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/update) method instead of getting fresh macOS VM image. When you get fresh macOS image you may need to make your custom configurations again.
+- You may need to make persistent proxy configuration for your internal network requirements.
+- You may need to add your corporate's self-signed root CAs to macOS VM image in order to succeed SSL connections.
+
+Steps, that we need to take, are technically similar as in [Create Base Images](#create-base-images) section. So, a conceptual overview of the steps will be sufficient.
+
+1. Stop all online runners as explained in [Stop VM](#stop-vm) section.
+2. Run `vm01` base image. `screen -d -m tart run vm01 --no-graphics`
+3. SSH into `vm01`. `ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm01)`
+4. Make your modifications, configurations or updates in macOS.
+5. Shutdown `vm01`
+6. Run `vm02` base image. `screen -d -m tart run vm02 --no-graphics`
+7. SSH into `vm02`. `ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm02)`
+8. Make your modifications, configurations or updates in macOS.
+9. Shutdown `vm02`.
+10. Start offline runners as explained in [Start VM](#start-vm) section.
+
+## Troubleshooting
+
+### Tart list has runner instance in list but I can not SSH into the runner
+
+Rarely your runner might hang or might become offline for some reason.
+
+- You can get its IP with `tart ip` but might not connect.
+- Although it's in `tart list` you might not get its IP.
+- Detached `screen` session might be terminated because of an error.
+
+You need to check your macOS host for possible system issues. (disk space, network connectivity, OS reboot etc.)
+
+You can also check runner's working directory for any error that might happen at virtualization. (`stderr.log`, `stdout.log`)
+
+In this case, you can make your runners operational again by following below steps.
+
+1- Make sure detached screen session and all its child processes terminated for the runner.
+
+For instance, you can find list of PIDs for "runner2" as seen below.
+
+```bash
+% ps aux | grep vm02 | grep -v grep
+appcircle        35640   0.0  0.1 408653856  18320 s002  S+    2:35PM   0:00.68 tart run vm02-3a003bce-a2ee-4ae7-9500-7754e181c314 --no-graphics
+appcircle        35174   0.0  0.0 408628512   2352 s002  S+    2:20PM   0:00.01 bash /Users/appcircle/runner2/run.sh vm02
+root             35173   0.0  0.0 408515456   6848 s002  Ss+   2:20PM   0:00.01 login -pflq appcircle /Users/appcircle/runner2/run.sh vm02
+appcircle        35172   0.0  0.0 408654848   1264   ??  Ss    2:20PM   0:00.00 SCREEN -d -m /Users/appcircle/runner2/run.sh vm02
+```
+
+2- Make sure there is no active virtualization framework process for the runner.
+
+For instance, you can filter like this.
+
+```bash
+% ps aux | grep -i virtualmachine | grep -v grep
+appcircle        35641   0.3 31.9 503225216 10699872   ??  Ss    2:35PM  42:07.38 /System/Library/Frameworks/Virtualization.framework/Versions/A/XPCServices/com.apple.Virtualization.VirtualMachine.xpc/Contents/MacOS/com.apple.Virtualization.VirtualMachine
+```
+
+3- Make sure there is no instance for the runner at VM list. If exists, remove it.
+
+For instance, we have an instance for "runner2" seen below.
+
+```bash
+% tart list
+Source Name                                      Size
+local  macOS_230309                              187
+local  vm01                                      140
+local  vm02                                      140
+local  vm02-3a003bce-a2ee-4ae7-9500-7754e181c314 125
+```
+
+Remove dangling "runner2".
+
+```bash
+tart delete vm02-3a003bce-a2ee-4ae7-9500-7754e181c314
+```
+
+4- Start VM for the runner as usual by following steps at [start VM](#start-vm).
+
+For instance, start "runner2" with command below.
+
+```bash
+screen -d -m $HOME/runner2/run.sh vm02
+```
+
+### I can SSH into runner but runner is offline at self-hosted runners list
+
+In this case, you need to focus on self-hosted runner issues inside macOS VM (guest).
+
+In order to be able to investigate root cause, you should learn the basics of self-hosted runner. Check our [online docs](https://docs.appcircle.io/self-hosted-appcircle/self-hosted-runner/overview) details.
+
+- You can check your macOS guest for possible system issues. (disk space, network connectivity etc.)
+- If you have custom proxy settings on macOS guest, check these settings.
+- If you added custom root CAs to macOS guest, verify their validity for SSL connection errors.
+- You can check runner launchd service and its logs. (`stdout.log`, `stderr.log`, `logs` etc.)
+- You should check network access from self-hosted runner to server. (firewall, open ports etc.)
+
+### Datetime I see in build logs is not correct
+
+This case is related with broken datetime synchronization between runner and server.
+
+Both server and runner should synchronize their times with relevant `ntp` services. Timezone difference is not important. Datetime must be correct in their timezones.
+
+If runner doesn't have network access to an NTP server on the internet, you can also configure it to use your internal NTP server.
+
+For updating macOS base image see [related section](#update-base-images) above.
+
+### Runners are offline and I noticed that macOS host has been reboot
+
+If there is no system crash, one reason for an unintentional reboot may be caused by automatic updates.
+
+We suggest disabling automatic updates on macOS host, and get them manually when required.
+
+Below are the CLI commands to disable all automatic updates on macOS.
+
+```bash
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool false
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 0
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool false
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -int 0
+sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -int 0
+```
+
+### Runners are offline but when I SSH into host, it suddenly becomes online
+
+When you install a fresh macOS on a mac device, it comes with predefined power settings which makes it energy efficient.
+
+So, most probably, your macOS host sleeps when there is no UI interaction, and awakes on SSH login.
+
+We suggest disabling those power settings to make it behave like a server station.
+
+```bash
+sudo pmset -a sleep 0
+sudo pmset -a powernap 0
+sudo pmset -a disksleep 0
+sudo pmset -a displaysleep 0
+```
+
+### I want to make some configurations to macOS base image but need desktop UI for them
+
+If you're not comfortable with CLI, you can also make your customizations using macOS desktop.
+
+For this purpose, remove `--no-graphics` argument from `tart run` commands.
+
+Below step in [update base images](#update-base-images) section,
+
+> 2- Run `vm01` base image. `screen -d -m tart run vm01 --no-graphics`
+
+should be like this in this case.
+
+> 2- Run `vm01` base image. `screen -d -m tart run vm01`

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -907,3 +907,7 @@ button[class*='toggleButton']:hover svg[class*='lightToggleIcon'] path {
 .section-title.best-practices > div >a::before {
   background-image: url(../../static/img/sidebar/best-practices.svg);
 }
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
Added the vm installation page to the Docusaurus as private page which is not listed in sidebar. 
Page is only accessible with direct url. 
Green tip box now forwards to the that private page.