### PR TITLE
#BE-1795 Removed Curl Command That Downloads The Install Script

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -66,3 +66,7 @@ Enter a URL or 'q' to quit: q
 ```
 
 After the script completes, the operating system, Java (11), Ruby and NodeJS trust the root cert.
+
+:::caution
+Please exit from the current terminal session and start a new one for changes to take effect.
+:::

--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -17,6 +17,7 @@ While adding root CAs and sub CAs to host, you should consider the following loc
 - `ca-certificates`, `ca-trust` (linux)
 - Ruby's `DEFAULT_CERT_DIR`
 - Java's keystore `cacerts`
+- Node.js `NODE_EXTRA_CA_CERTS`
 
 ## Adding Certificates
 
@@ -26,9 +27,9 @@ If your runner version `1.3.12` or later, you can find it in the `scripts` direc
 
 If your runner version is older than `1.3.12`, then you can follow one of the steps below:
 
-- [Upgrade](../update.md#1-update-runner) the Appcircle runner to 1.3.12 or later
+- [Upgrade](../update.md#1-update-runner) the Appcircle runner to `1.3.12` or later
 
-- If you can't upgrade the Appcircle runner, you can [download the latest](../update.md#1-update-runner) Runner package and get script.
+- If you can't upgrade the Appcircle runner, you can [download the latest](../update.md#1-update-runner) runner package and get the script from there after you extract the archive.
 
 Execute the bash script like below.
 
@@ -65,7 +66,7 @@ Enter a URL or 'q' to quit: q
 %
 ```
 
-After the script completes, the operating system, Java (11), Ruby and NodeJS trust the root cert.
+After the script is complete, the operating system, default Java (`11`), Ruby, and Node.js trust the root certificate.
 
 :::caution
 Please exit from the current terminal session and start a new one for changes to take effect.

--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -22,16 +22,15 @@ While adding root CAs and sub CAs to host, you should consider the following loc
 
 The self-hosted runner has a command-line tool to help you install the required certificates. When called, it connects to the given host via the URL and extracts the root CA. It adds the root CA to the locations listed above.
 
-If your runner version `1.3.12` or later, you can find it in the root directory of the runner installation.
+If your runner version `1.3.12` or later, you can find it in the `scripts` directory inside the Appcircle runner directory.
 
-If your runner version is older, then you can get it from Appcircle CDN with the below commands.
+If your runner version is older than `1.3.12`, then you can follow one of the steps below:
 
-```bash
-curl -L -O https://storage.googleapis.com/appcircle-dev-common/self-hosted/install_cert.sh
-chmod u+x install_cert.sh
-```
+- [Upgrade](../update.md#1-update-runner) the Appcircle runner to 1.3.12 or later
 
-Simply execute the bash script.
+- If you can't upgrade the Appcircle runner, you can [download the latest](../update.md#1-update-runner) Runner package and get script.
+
+Execute the bash script like below.
 
 ```bash
 ./install_cert.sh
@@ -66,13 +65,4 @@ Enter a URL or 'q' to quit: q
 %
 ```
 
-:::info
-
-NodeJS doesn't use the system CA store so you need to take extra steps.
-
-For self-sigend certificates, you have two options:
-
-1. Add the `NODE_EXTRA_CA_CERTS="rootCA.pem"`  environment variable. It is possible to add multiple certificates in a single file.
-2. Add the `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable. This completely disables SSL verification (not recommended).
-
-:::
+After the script completes, the operating system, Java (11), Ruby and NodeJS trust the root cert.


### PR DESCRIPTION
Removed curl command that downloads the install script.
Also removed the NodeJs warning because we install the cert to NodeJs by default. 