### PR TITLE
#BE-1633 Added Guide For Manual Usage Install Cert Script

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -72,36 +72,36 @@ After the script is complete, the operating system, default Java (`11`), Ruby, a
 Please exit from the current terminal session and start a new one for changes to take effect.
 :::
 
-## Adding Certificates Manually
+### Adding Certificates Manually
 
 In situations where automatic root certificate detection may not work, the bash script provides a user-friendly manual trust method.
 
-Users can supply the root certificate themselves to the `install_cert.sh` script.
+Users can supply the root certificates themselves locally to the tool and import them.
 
-Once imported, your system and some programming languages will trust the certificate, ensuring secure connections to the server.
+Once imported, the operating system and other tools listed above will trust the certificate, ensuring secure connections to the server, just like getting them from a URL.
 
-If the `install_cert.sh` can't auto-detect the root CA, follow the steps below:
+If `install_cert.sh` can't auto-detect the root CA from URL, follow the steps below to import it from disk:
 
-- Get your organization's root CA and copy it.
+- Get your organization's root CA and copy its content.
 
-- Go to the `appcircle-runner` and `scripts` directory.
+- Go to the `scripts` directory, which is in the `appcircle-runner` directory.
 
-- Create a file named `rootca.crt` and paste the rootca inside it.
+- Create a file named `rootca.crt` and paste the root CA content inside it.
 
 ```bash
 vi rootca.crt
 ```
 
-- To use the `install_cert.sh` in manual mode, you should provide the root CA and a url to test the connection.
+- To use the `install_cert.sh` in manual mode, you should provide the root CA and a URL to test the connection.
 
 ```bash
 ./install_cert.sh <path to the CA cert> <url to test connection>
 ```
 
-- For example, if you saved the root CA in the `rootca.crt` file and want to test the connection to the Appcircle server, see the example below:
+For example, if you saved the root CA in the `rootca.crt` file and want to test the connection to the Appcircle server, see the example below:
 
 ```bash
 ./install_cert.sh rootca.crt api.appcircle.spacetech.com
 ```
 
-- After the script completes successfully, the root certificate will be trusted in your system.
+After the script completes successfully, the certificate will be trusted in your system.

--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -92,13 +92,17 @@ If `install_cert.sh` can't auto-detect the root CA from URL, follow the steps be
 vi rootca.crt
 ```
 
+:::info
+Alternatively, you can push the certificate files to the runner disk and use them directly as certificate arguments.
+:::
+
 - To use the `install_cert.sh` in manual mode, you should provide the root CA and a URL to test the connection.
 
 ```bash
 ./install_cert.sh <path to the CA cert> <url to test connection>
 ```
 
-For example, if you saved the root CA in the `rootca.crt` file and want to test the connection to the Appcircle server, see the example below:
+For example, if you saved the root CA in the `rootca.crt` file and want to import and test the connection to the Appcircle server, see the example below:
 
 ```bash
 ./install_cert.sh rootca.crt api.appcircle.spacetech.com

--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -72,7 +72,41 @@ NodeJS doesn't use the system CA store so you need to take extra steps.
 
 For self-sigend certificates, you have two options:
 
-1. Add the `NODE_EXTRA_CA_CERTS="rootCA.pem"`  environment variable. It is possible to add multiple certificates in a single file.
+1. Add the `NODE_EXTRA_CA_CERTS="rootCA.pem"` environment variable. It is possible to add multiple certificates in a single file.
 2. Add the `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable. This completely disables SSL verification (not recommended).
 
 :::
+
+## Adding Certificates Manually
+
+In situations where automatic root certificate detection may not work, the bash script provides a user-friendly manual trust method.
+
+Users can supply the root certificate themselves to the `install_cert.sh` script.
+
+Once imported, your system and some programming languages will trust the certificate, ensuring secure connections to the server.
+
+If the `install_cert.sh` can't auto-detect the root CA, follow the steps below:
+
+- Get your organization's root CA and copy it.
+
+- Go to the `appcircle-runner` and `scripts` folder.
+
+- Create a file named `rootca.crt` and paste the rootca inside it.
+
+```bash
+vi rootca.crt
+```
+
+- To use the `install_cert.sh` in manual mode, you should provide the root CA and a url to test the connection.
+
+```bash
+./install_cert.sh <path to the CA cert> <url to test connection>
+```
+
+- For example, if you saved the root CA in the `rootca.crt` file and want to test the connection to the Appcircle server, see the example below:
+
+```bash
+./install_cert.sh rootca.crt api.appcircle.spacetech.com
+```
+
+- After the script completes successfully, the root certificate will be trusted in your system.

--- a/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md
@@ -89,7 +89,7 @@ If the `install_cert.sh` can't auto-detect the root CA, follow the steps below:
 
 - Get your organization's root CA and copy it.
 
-- Go to the `appcircle-runner` and `scripts` folder.
+- Go to the `appcircle-runner` and `scripts` directory.
 
 - Create a file named `rootca.crt` and paste the rootca inside it.
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -359,7 +359,7 @@ After login, configuration steps for Appcircle runner service are the same as "r
 
 The only difference should be runner naming. It must be unique. For the second runner, just give a different name. For example, "runner2".
 
-Refer to the [Configure Appcircle Runner Service](#configure-appcircle-runner-service) for detailed Appcircle runner service configuration.
+Refer to the [Configure Runner Service](#3-configure-runner-service) for detailed Appcircle runner service configuration.
 
 After shutdown, we're ready to run instances from `vm01` and `vm02` base VM images.
 


### PR DESCRIPTION
Self signed certificates page now includes a guide on how users can use the install cert script manually by providing root ca.