### PR TITLE
feature(BE-2071): Add a tool for broken links and fix them using the tool

### DIFF
--- a/docs/build/build-profile-configuration.md
+++ b/docs/build/build-profile-configuration.md
@@ -61,7 +61,7 @@ Every build profile needs to know project details regardless of the project bein
 You can also select your self-hosted runner from the **SELECT A POOL** dropdown.
 
 
-<ContentRef url="/self-hosted-runner/overview">
+<ContentRef url="/self-hosted-appcircle/self-hosted-runner/overview">
   Self-Hosted Runners
 </ContentRef>
 

--- a/docs/build/building-react-native-applications.md
+++ b/docs/build/building-react-native-applications.md
@@ -26,7 +26,7 @@ Simply create a new build profile as usual and select your target operating syst
 
 Once your build profile is created, click on it and connect your Git repository. For details on this step, please follow the directions on the following page:
 
-<ContentRef url="../build/adding-a-build-profile">Adding a Build Profile</ContentRef>
+<ContentRef url="/build/adding-a-build-profile">Adding a Build Profile</ContentRef>
 
 ### Build Configuration for React Native Applications
 

--- a/docs/self-hosted-appcircle/faq.md
+++ b/docs/self-hosted-appcircle/faq.md
@@ -71,7 +71,7 @@ The runner VMs cannot connect to the servers to update their date and time due t
 
 You should configure NTP server settings in the runner VMs. For updating base runners, please refer to the [Update Base Images](./self-hosted-runner/runner-vm-setup.md#update-base-images) section.
 
-For details on configuring NTP settings, you can refer to the [NTP Configuration](./self-hosted-runner/runner-vm-setup.md#1-configure-base-runners-ntp-settings) section and follow the steps.
+For details on configuring NTP settings, you can refer to the [NTP Configuration](./self-hosted-runner/runner-vm-setup.md#2-configure-base-runners-ntp-settings) section and follow the steps.
 
 ### We can't register Appcircle runner to the server.
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -245,7 +245,7 @@ Using `-o android` in this case will be wrong argument. You must use `-o ios,and
 
 If you're using self-signed certificates, you need to follow the below document to add your certificates to runners.
 
-<ContentRef url="/self-hosted-appcircle/self-hosted-runner/custom-certificates">
+<ContentRef url="/self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates">
   Self-Signed Certificates
 </ContentRef>
 

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -425,7 +425,7 @@ After login, configuration steps for Appcircle runner service are the same as "r
 
 The only difference should be runner naming. It must be unique. For the second runner, just give a different name. For example, "runner2".
 
-Refer to the [Configure Runner Service](#3-configure-runner-service) for detailed Appcircle runner service configuration.
+Refer to the [Configure Runner Service](#4-configure-runner-service) for detailed Appcircle runner service configuration.
 
 After shutdown, we're ready to run instances from `vm01` and `vm02` base VM images.
 
@@ -682,7 +682,7 @@ If runner doesn't have network access to an NTP server on the internet, you can 
 
 For updating macOS base image see [related section](#update-base-images) above.
 
-For configuring NTP settings, see [Configure Base Runner's NTP Settings](#1-configure-base-runners-ntp-settings) section above.
+For configuring NTP settings, see [Configure Base Runner's NTP Settings](#2-configure-base-runners-ntp-settings) section above.
 
 ### I am facing "SSL cert is not valid yet" error in our builds
 
@@ -692,7 +692,7 @@ To fix that, you should sync the VMs' date and time with your organization's NTP
 
 For updating macOS base image see [related section](#update-base-images) above.
 
-For configuring NTP settings, see [Configure Base Runner's NTP Settings](#1-configure-base-runners-ntp-settings) section above.
+For configuring NTP settings, see [Configure Base Runner's NTP Settings](#2-configure-base-runners-ntp-settings) section above.
 
 ### Runners are offline and I noticed that macOS host has been reboot
 

--- a/docs/updates/release-notes.md
+++ b/docs/updates/release-notes.md
@@ -71,7 +71,7 @@ import CloudBadge from '@site/src/components/CloudBadge';
 - The latest stable version of [Xcode 15.0](../build/building-ios-applications.md) is available on both cloud and self-hosted runners. <SelfHostedBadge/> <CloudBadge/>
 - The self-hosted Appcircle server now supports proxies with a [self-signed certificate.](../self-hosted-appcircle/configure-server/proxy-configuration.md) <SelfHostedBadge/>
 - Users can more easily switch to the self-hosted version of their choice by only [downloading](../self-hosted-appcircle/update.md#1-download-latest) the server package. <SelfHostedBadge/>
-- Added the [NTP configuration](../self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md#1-configure-base-runners-ntp-settings) helper tool to the self-hosted runner package. <SelfHostedBadge/>
+- Added the [NTP configuration](../self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md#2-configure-base-runners-ntp-settings) helper tool to the self-hosted runner package. <SelfHostedBadge/>
 - Added self-signed certificate management for Node.JS to the [certificate installer](../self-hosted-appcircle/self-hosted-runner/configure-runner/custom-certificates.md#adding-certificates) tool. <SelfHostedBadge/>
 - Now you can analyze your [SwiftLint](../integrations/azure-bot-for-swiftlint-and-detekt.md#azure-devops-bot-for-swiftlint) and [Detekt](../integrations/azure-bot-for-swiftlint-and-detekt.md#azure-devops-bot-for-detekt) reports and post the report details under the opened PR on Azure DevOps. <CloudBadge/> <SelfHostedBadge/>
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && yarn check-broken-links",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "yarn check-broken-links && docusaurus serve",
+    "serve": "docusaurus serve",
     "textlint": "textlint --dry-run ./docs/",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "yarn check-broken-links && docusaurus serve",
     "textlint": "textlint --dry-run ./docs/",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "check-broken-links": "npx @untitaker/hyperlink ./build --check-anchors"
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.3",
@@ -22,15 +23,16 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "docusaurus-plugin-sass": "^0.2.2",
+    "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-link-card": "^1.3.1",
-    "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "sass": "^1.54.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.3",
+    "@untitaker/hyperlink": "^0.1.31",
     "textlint": "^12.2.1",
     "textlint-rule-no-dead-relative-link": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,6 +2317,11 @@
   dependencies:
     "@types/node" "*"
 
+"@untitaker/hyperlink@^0.1.31":
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/@untitaker/hyperlink/-/hyperlink-0.1.31.tgz#3bd1312378e2b59b089db1bb0e0c0457c9d0370f"
+  integrity sha512-qalkLdZkZ5Ymu3RH5jWblY6+Rmg+0zmtYy8xHoKghq458BQKKcfezD8Uj7oynm/7jwkyNBxfqI/EaVGzVQr2/g==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
Note: It would be awesome if we could add this to deploy steps. Currently, developers have to manually launch this. Our options:

1. Add to the e.g. `yarn build` step like `build: "docusaurus build && yarn check-broken-links"`
2. Add as a separate step. Note that it should be **AFTER** the build step since it checks for HTML content.