### PR TITLE
BE-2755 JDK updates | sdkman usage for system java

### DIFF
--- a/docs/infrastructure/android-build-infrastructure.md
+++ b/docs/infrastructure/android-build-infrastructure.md
@@ -34,27 +34,31 @@ Please note that virtual machines are wiped off after a build is executed (no ma
 
 ## Java Version
 
-Build agents have Java 8, 11, and 17 installed. Java 11 is set as the default version. If you want to use a different Java version. please follow [this document](../integrations/working-with-custom-scripts/custom-script-samples.md#changing-java-version)
+Build agents have Java 8, 11, 17 and 21 installed. Java 11 is set as the default version.
+
+If you want to use a different Java version, please follow [this document](../integrations/working-with-custom-scripts/custom-script-samples.md#changing-java-version) for how to do that.
 
 When you select "Default Intel Pool" for Android builds, the following JDK locations are available within the environment variables:
 
 - **JAVA_HOME_8_X64**: `/usr/local/openjdk-8`
 - **JAVA_HOME_11_X64**: `/root/.sdkman/candidates/java/11.0.12-open`
 - **JAVA_HOME_17_X64**: -
+- **JAVA_HOME_21_X64**: -
 
 :::caution
 We're deprecating Intel-based runners and transitioning our customers to Apple silicon (M1)-based build machines.
 
-Currently, JDK 17 is not pre-installed on the "Default Intel Pool", and Intel-based runners are not actively maintained.
+Currently, JDK 17 and 21 are not pre-installed on the "Default Intel Pool", and Intel-based runners are not actively maintained.
 
 If your app does not specifically require an Intel-based build machine, we suggest you use "Default M1 Pool", since it has much more build capacity and the latest updates.
 :::
 
 When you select "Default M1 Pool" for Android builds, the following JDK locations are available within the environment variables:
 
-- **JAVA_HOME_8_X64**: `/Users/appcircle/.sdkman/candidates/java/8.0.332-zulu`
-- **JAVA_HOME_11_X64**: `/Users/appcircle/.sdkman/candidates/java/11.0.14-zulu`
-- **JAVA_HOME_17_X64**: `/Users/appcircle/.sdkman/candidates/java/17.0.7-zulu`
+- **JAVA_HOME_8_X64**: `/Users/appcircle/.sdkman/candidates/java/8.0.392-zulu`
+- **JAVA_HOME_11_X64**: `/Users/appcircle/.sdkman/candidates/java/11.0.21-zulu`
+- **JAVA_HOME_17_X64**: `/Users/appcircle/.sdkman/candidates/java/17.0.9-zulu`
+- **JAVA_HOME_21_X64**: `/Users/appcircle/.sdkman/candidates/java/21.0.2-zulu`
 
 ## Emulator
 
@@ -109,7 +113,7 @@ Here are some most important packages installed in our Linux and macOS images us
 | Git LFS             | 2.13.2          | 3.3.0           | 3.2.0             |
 | Gradle              | 4.4.1           | 7.6             | 7.5.1             |
 | Gzip                | 1.10.4          | 403.100.6       | 353.100.22        |
-| Java                | 11.0.12         | 11.0.14         | 11.0.14           |
+| Java                | 11.0.12         | 11.0.21         | 11.0.21           |
 | Maven               | 3.8.6           | 3.9.4           | 3.8.6             |
 | Node JS             | 16.18.1         | 16.20.2         | 16.18.1           |
 | OpenSSL             | 1.1.1           | 3.3.6           | 2.8.3             |

--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -59,7 +59,7 @@ Here are some of the most important packages installed in our iOS build agents u
 | Carthage           | 0.38.0           | 0.38.0          | 0.38.0     |
 | Curl               | 7.79.1           | 8.1.2           | 7.79.1     |
 | Homebrew           | 3.6.11           | 3.6.16          | 3.4.2      |
-| Java (OpenJDK)     | 11.0.14          | 11.0.14         | 11.0.2     |
+| Java (OpenJDK)     | 11.0.21          | 11.0.21         | 11.0.2     |
 | Gem                | 3.1.6            | 3.1.6           | 3.1.6      |
 | Fastlane           | 2.211.0          | 2.214.0         | 2.204.3    |
 | Git                | 2.38.1           | 2.39.0          | 2.35.1     |

--- a/docs/integrations/working-with-custom-scripts/custom-script-samples.md
+++ b/docs/integrations/working-with-custom-scripts/custom-script-samples.md
@@ -11,9 +11,11 @@ import Screenshot from '@site/src/components/Screenshot';
 
 ### Changing JAVA version
 
-If you want to change the JAVA version for your Android project, you can achieve this by changing the JAVA_HOME environment variable. Appcircle currently has OpenJDK 11(default), OpenJDK 8 and OpenJDK 17. You can use the below custom script before your build step for this task.
+If you want to change the JAVA version for your Android project, you can achieve this by changing the `JAVA_HOME` environment variable.
 
-Appcircle Android build uses OpenJDK 11 as a default. Build machines also have OpenJDK 8 and OpenJDK 17 as well. You can use the below custom script to change your JAVA_HOME environment variable.
+Appcircle currently has OpenJDK 11 (default), OpenJDK 8, OpenJDK 17 and OpenJDK 21.
+
+You can use the below custom script before your build step to change your `JAVA_HOME` environment variable.
 
 ```bash
 echo "Default JAVA" $JAVA_HOME
@@ -21,6 +23,7 @@ echo "Default JAVA" $JAVA_HOME
 echo "OpenJDK 8" $JAVA_HOME_8_X64
 echo "OpenJDK 11" $JAVA_HOME_11_X64
 echo "OpenJDK 17" $JAVA_HOME_17_X64
+echo "OpenJDK 21" $JAVA_HOME_21_X64
 
 # Change JAVA_HOME to OPENJDK 17
 echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $AC_ENV_FILE_PATH
@@ -32,9 +35,42 @@ Create a custom script like above and put it **above** your Android build step.
 
 <Screenshot url="https://cdn.appcircle.io/docs/assets/workflow-android-change-java-workflow-detail.png" />
 
+:::caution
+
+Please be aware that this custom script affects any step that comes after.
+
+Therefore, you should use this step as a standalone step instead of as part of any custom script.
+
+:::
+
+:::tip
+
+You can find more details about the included Java versions on the [Android Build Infrastructure](../../infrastructure/android-build-infrastructure.md#java-version) page.
+
+:::
+
 :::info
 
-Please be aware that this custom script affects any step that comes after. Therefore you should use this step as a standalone step not as a part of any custom script.
+#### Changing System Java Version
+
+Changing the `JAVA_HOME` environment variable will be enough for your Android builds, but it won't change the `java` version in the system.
+
+If you're using a tool in the build pipeline that requires another Java version than the default OpenJDK 11, you should also change the system's default Java version using the below commands in the custom script.
+
+```bash
+source "$SDKMAN_DIR/bin/sdkman-init.sh"
+sdk default java $(basename $JAVA_HOME_17_X64)
+```
+
+After that, you will see the output of `java -version` as below in the build logs.
+
+```txt
+openjdk version "17.0.7" 2023-04-18 LTS
+OpenJDK Runtime Environment Zulu17.42+19-CA (build 17.0.7+7-LTS)
+OpenJDK 64-Bit Server VM Zulu17.42+19-CA (build 17.0.7+7-LTS, mixed mode, sharing)
+```
+
+You can also switch to other pre-installed Java versions using the relevant environment variable as an argument in the `sdk` command. For more details about these environment variables, see the [Android Build Infrastructure](../../infrastructure/android-build-infrastructure.md#java-version) page.
 
 :::
 

--- a/docs/troubleshooting-faq/common-issues.md
+++ b/docs/troubleshooting-faq/common-issues.md
@@ -325,7 +325,7 @@ Every Android project has a `gradlew` file in the main repository directory. If 
 
 ### How can I change the JDK version for autofill?
 
-Appcircle currently has OpenJDK 11 (default), OpenJDK 8, and OpenJDK 17. If you want to use a different Java version for your build pipeline, you can follow the steps [here](../integrations/working-with-custom-scripts/custom-script-samples.md#changing-java-version) and add a custom script to your workflow.
+Appcircle currently has OpenJDK 11 (default), OpenJDK 8, OpenJDK 17 and OpenJDK 21. If you want to use a different Java version for your build pipeline, you can follow the steps [here](../integrations/working-with-custom-scripts/custom-script-samples.md#changing-java-version) and add a custom script to your workflow.
 
 But unfortunately, you cannot use custom scripts for autofill operations, which make it easy to fill in configuration details while adding a new build profile.
 
@@ -338,7 +338,7 @@ You can add the `org.gradle.java.home` entry to the `gradle.properties` file in 
 For example, the below entry can be used to change the default Java version to 17 for the "Default M1 Pool".
 
 ```properties
-org.gradle.java.home=/Users/appcircle/.sdkman/candidates/java/17.0.7-zulu
+org.gradle.java.home=/Users/appcircle/.sdkman/candidates/java/17.0.9-zulu
 ```
 
 You can get the JDK home paths for each build pool from [Android's build infrastructure](../infrastructure/android-build-infrastructure.md#java-version) Java section.
@@ -351,7 +351,7 @@ For example, you can take the following steps to change the default Java version
 
 1. Create a variable group that has a variable with the properties below.
     1. The key should be `JAVA_HOME`.
-    2. Value should be `/Users/appcircle/.sdkman/candidates/java/17.0.7-zulu`.
+    2. Value should be `/Users/appcircle/.sdkman/candidates/java/17.0.9-zulu`.
 2. Go to the configuration section of the build profile that you want to autofill.
 3. Go to the 'Env. Variables' tab in configuration.
     1. You should see the variable group that you created in the list.

--- a/docs/troubleshooting-faq/common-issues.md
+++ b/docs/troubleshooting-faq/common-issues.md
@@ -465,7 +465,7 @@ lib/src/core/dependency/myservice.dart:12:8: Error: Error when reading ‘lib/sr
 
 This error usually indicates that you didn't name your files according to Dart convention. Linux file system is case sensitive whereas Windows and macOS are not. So if your repository has `customerrepository.dart` but you're importing as `CustomerRepository.dart`, it will not work on Linux machines. To prevent this error, please rename your files and make them all lower case. Please read the following documentation related to styling and naming your files.
 
-https://dart.dev/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores
+<ContentRef url="https://dart.dev/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores">Effective Dart: Style | name packages, directories, and source files</ContentRef>
 
 ### Firebase Version
 Your build may fail with following error


### PR DESCRIPTION
PR includes changes for the latest  JDK upgrades in the runner environment.

It also has a new "info" section that explains how to change the system `java` version for other 3rd party tools.