### PR TITLE
Redirect rules for broken links

### DIFF
--- a/docs/publish-module/send-to-huawei.md
+++ b/docs/publish-module/send-to-huawei.md
@@ -44,7 +44,7 @@ Your uploaded keystore file should also be uploaded to Huawei AppGallery. Follow
 
 ### Deploying the Binary from the Testing Distribution
 
-You can deploy the binaries to the Publish module from the [Testing Distribution](https://docs.appcircle.io/distribute/create-or-select-a-distribution-profile.md). Both directly uploaded apps and built apps deployed from the build module are supported as long as they are valid for Huawei AppGallery. (e.g. in [release mode](https://docs.appcircle.io/build/building-android-applications/) and [signed](https://docs.appcircle.io/signing-identities/android-keystores) properly if APK - you can manage this in the [build configuration](https://docs.appcircle.io/build/build-profile-configuration.) for all types of development frameworks.)
+You can deploy the binaries to the Publish module from the [Testing Distribution](https://docs.appcircle.io/distribute/create-or-select-a-distribution-profile). Both directly uploaded apps and built apps deployed from the build module are supported as long as they are valid for Huawei AppGallery. (e.g. in [release mode](https://docs.appcircle.io/build/building-android-applications/) and [signed](https://docs.appcircle.io/signing-identities/android-keystores) properly if APK - you can manage this in the [build configuration](https://docs.appcircle.io/build/build-profile-configuration.) for all types of development frameworks.)
 
 Select a binary in the list and press "Send to Publish" from the three dots. The package name of the binary will be matched automatically if there is an existing Publish profile. If not, you have to create a new Publish profile.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   status = 301
 
 [[redirects]]
-  from = "/building-multiple-apps-in-one-profile"
+  from = "/integrations/building-multiple-apps-in-one-profile"
   to = "/best-practices/building-multiple-apps-in-one-profile"
   status = 301
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,38 @@
   from = "/workflows/why-to-use-workflows"
   to = "/workflows"
   status = 301
+
+[[redirects]]
+  from = "/store-submit/apple-app-store"
+  to = "/publish-module/send-to-appstore"
+  status = 301
+
+[[redirects]]
+  from = "/building-multiple-apps-in-one-profile"
+  to = "/best-practices/building-multiple-apps-in-one-profile"
+  status = 301
+
+[[redirects]]
+  from = "/distribute/create-or-select-a-distribution-profile.md"
+  to = "/distribute/create-or-select-a-distribution-profile"
+  status = 301
+
+[[redirects]]
+  from = "/integrations/custom-script-samples"
+  to = "/integrations/working-with-custom-scripts/custom-script-samples"
+  status = 301
+
+[[redirects]]
+  from = "/integrations/custom-script-faq"
+  to = "/integrations/working-with-custom-scripts/custom-script-faq"
+  status=301
+
+[[redirects]]
+  from = "/build-manually-or-with-triggers"
+  to = "/build/build-manually-or-with-triggers"
+  status = 301
+
+[[redirects]]
+  from ="/adding-a-build-profile/connecting-to-private-repository-via-ssh"
+  to = "/build/adding-a-build-profile/connecting-to-private-repository-via-ssh"
+  status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   status = 301
 
 [[redirects]]
-  from = "/integrations/building-multiple-apps-in-one-profile"
+  from = "/building-multiple-apps-in-one-profile"
   to = "/best-practices/building-multiple-apps-in-one-profile"
   status = 301
 


### PR DESCRIPTION
Below are the SEO reported links:

- https://docs.appcircle.io/store-submit/apple-app-store
- https://docs.appcircle.io/adding-a-build-profile/connecting-to-private-repository-via-ssh
- https://docs.appcircle.io/build-manually-or-with-triggers
- https://docs.appcircle.io/integrations/custom-script-faq
- https://docs.appcircle.io/integrations/custom-script-samples
- https://docs.appcircle.io/build/build-profile-configuration (not a broken link!)
- https://docs.appcircle.io/distribute/create-or-select-a-distribution-profile.md
- https://docs.appcircle.io/building-multiple-apps-in-one-profile

 