### PR TITLE
BE-2904 Remove isolation from differences table

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/index.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/index.md
@@ -31,7 +31,7 @@ See [pricing](https://appcircle.io/pricing) and feature comparison table for det
 - Has some operating system level optimizations
 - Preinstalled packages and tools regularly updated
 - Are managed and maintained by Appcircle
-- Provides a clean, isolated instance for every build job
+- Provides a clean instance for every build job
 - Can take longer to start your build (waiting in queue)
 
 **Self-hosted runners:**

--- a/docs/self-hosted-appcircle/self-hosted-runner/index.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/index.md
@@ -44,7 +44,7 @@ See [pricing](https://appcircle.io/pricing) and feature comparison table for det
 :::info
 On self-hosted runners, you can have a clean and isolated instance for each build, just like Appcircle Cloud.
 
-In this case, we recommend running a single runner per (virtual) machine for better isolation if you need concurrency. Using a well established virtualization infrastructure, such as a virtual machine or Docker container, for self-hosted runner helps you to run every build on a clean state.
+In this case, we recommend running a single runner per (virtual) machine for better isolation if you need concurrency. Using a well-established virtualization infrastructure, such as a virtual machine or Docker container, for a self-hosted runner also helps you to run every build on a clean state.
 :::
 
 ## Runner Pools

--- a/docs/self-hosted-appcircle/self-hosted-runner/index.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/index.md
@@ -41,6 +41,12 @@ See [pricing](https://appcircle.io/pricing) and feature comparison table for det
 - Don't need to have a clean instance for every build job (reusable caches)
 - Not waiting in build queue for other users' build jobs (private queue)
 
+:::info
+On self-hosted runners, you can have a clean and isolated instance for each build, just like Appcircle Cloud.
+
+In this case, we recommend running a single runner per (virtual) machine for better isolation if you need concurrency. Using a well established virtualization infrastructure, such as a virtual machine or Docker container, for self-hosted runner helps you to run every build on a clean state.
+:::
+
 ## Runner Pools
 
 Runner pools are a way of grouping many runners with similar build capabilities and assigning them to build profiles with a single click. You can group and organize your runners according to installed platform tools, operating systems or architectures. You can use any number of pools for your needs.


### PR DESCRIPTION
> **Differences Between Appcircle-hosted and Self-hosted Runners**
> _Appcircle-hosted runners:_
> - Provides a clean, isolated instance for every build job
> ...
>
> _Self-hosted runners:_
> - Don't need to have a clean instance for every build job (reusable caches)
---
:question: Mete: 
> ... eğer müşteri self – hosted kullanırsa biz isolasyon yapmıyoruz gibi bir anlam çıkmıyor mu?

I removed the "isolation" from the table since it should only have differences between cloud and self-hosted runners. Both supported features are out of scope for this section.
