### PR TITLE
Fix broken docusaurus info boxes

### DIFF
--- a/docs/enterprise-appstore/enterprise-app-store-setup/configure-ent-profile.md
+++ b/docs/enterprise-appstore/enterprise-app-store-setup/configure-ent-profile.md
@@ -107,7 +107,8 @@ You can access the relevant terms and conditions from the links below and get de
 - [Apple Developer Enterprise Program Agreement](https://developer.apple.com/support/downloads/terms/apple-developer-enterprise-program/Apple-Developer-Enterprise-Program-License-Agreement-20230605-English.pdf)
   - See Section 2.1 on page 8 for usage and restrictions, and Section 11.2 on page 33 for terms and terminations.
 - [Apple Developer Enterprise Program](https://developer.apple.com/programs/enterprise/)
-  :::
+
+:::
 
 :::info
 

--- a/docs/workflows/android-specific-workflow-steps/build-and-test/android-build-for-ui-testing.md
+++ b/docs/workflows/android-specific-workflow-steps/build-and-test/android-build-for-ui-testing.md
@@ -23,14 +23,16 @@ The workflow steps that need to be executed before running the **Android Build f
 If you're updating the version via Appcircle, ensure that the following step comes before the **Android Build for UI Testing** step:
 
 - [**Android Increment Build and Version Number**](https://docs.appcircle.io/workflows/android-specific-workflow-steps/increment-build-and-version-number)
-  :::
+
+:::
 
 :::caution
 If you're working with a **React Native Android** project, ensure that the following steps come before the **Android Build for UI Testing** step:
 
 - [**Install Node**](https://docs.appcircle.io/workflows/react-native-specific-workflow-steps/#install-node)
 - [**NPM/Yarn Commands**](https://docs.appcircle.io/workflows/react-native-specific-workflow-steps/npm-yarn-commands)
-  :::
+
+:::
 
 <Screenshot url='https://cdn.appcircle.io/docs/assets/android-workflow-components-android-build-for-ui-testing_1.png'/>
 

--- a/docs/workflows/android-specific-workflow-steps/build-and-test/lint.md
+++ b/docs/workflows/android-specific-workflow-steps/build-and-test/lint.md
@@ -47,7 +47,8 @@ If you have filled in the required variables in the **Configuration** section, y
 
 1. The input corresponds to the 1st field: `$AC_MODULE`
 2. The input corresponds to the 2nd field: `$AC_VARIANTS`
-   :::
+
+:::
 
 ### Output Variables
 


### PR DESCRIPTION
List items should be seperated from `:::` with leading and trailing lines. [ref](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md032---lists-should-be-surrounded-by-blank-lines)

Formatter behaviour is OK for this case. Fixed `:::`.