### PR TITLE
BE-3129 Update macOS VM image docs - 240417

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -35,7 +35,7 @@ Please note that virtual machines are wiped off after a build is executed (no ma
 
 ## Available Xcode Versions
 
-Our macOS build agents have Xcode versions 15.3.x, 15.2.x, 15.1.x, 15.0.x, 14.3.x, 14.2.x, 14.1.x, 14.0.x, 13.4.x, 13.3.x, 13.2.x, 13.1.x, 13.0.x, 12.5.x available.
+Our macOS build agents have Xcode versions 15.4.x, 15.3.x, 15.2.x, 15.1.x, 15.0.x, 14.3.x, 14.2.x, 14.1.x, 14.0.x, 13.4.x, 13.3.x, 13.2.x, 13.1.x, 13.0.x, 12.5.x available.
 
 :::caution
 Xcode `14.3.x` or higher Xcode versions require a Mac running macOS Ventura 13.0 or later.

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -5,6 +5,9 @@ tags: [self-hosted runner, runner, vm, virtual machine, setup]
 sidebar_class_name: hidden
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Self-hosted Runner as MacOS VM Image
 
 Self-hosted runner installation is explained at Appcircle [docs](installation) in detail. You can install runner in your self-hosted environment by yourself, following instructions on there.
@@ -116,57 +119,165 @@ You can ignore power failure settings if they are not supported.
 
 ## Download MacOS VM
 
+:::tip
+
+MacOS VM image has a versioning convention based on release date instead of arbitrary numbers. This date-based approach is called calendar versioning, or CalVer for short.
+
+Our calendar versioning scheme for the macOS image is `YY0M0D`. For example, a macOS image that's released on March 6, 2024, should have version `240306`.
+
+The versions are listed in chronological order, from the earliest to the most recent, in the tabs below.
+
+:::
+
 Download macOS VM from Appcircle bucket.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240306.tar.gz
 ```
 
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240417.tar.gz
+```
+
+  </TabItem>
+</Tabs>
+
 If you encounter network interruption, just run the same command again. It should continue download for remaining part. It will result in saving both time and bandwidth.
 
 ---
 
 **Note:** You can check the integrity of downloaded file by comparing the MD5 checksum.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 md5 macOS_240306.tar.gz
 ```
 
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+md5 macOS_240417.tar.gz
+```
+
+  </TabItem>
+</Tabs>
+
 After a couple of minutes later you should see the output below.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 MD5 (macOS_240306.tar.gz) = 084a9221075ed5453aceba6a3438b134
 ```
 
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+MD5 (macOS_240417.tar.gz) = 781b29c712927a664d09e605524f3ed6
+```
+
+  </TabItem>
+</Tabs>
+
 ---
 
 Create folder for VM.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 mkdir -p $HOME/.tart/vms/macOS_240306
 ```
 
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+mkdir -p $HOME/.tart/vms/macOS_240417
+```
+
+  </TabItem>
+</Tabs>
+
 Extract archive into VMs folder.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 tar -zxf macOS_240306.tar.gz --directory $HOME/.tart/vms/macOS_240306
 ```
 
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+tar -zxf macOS_240417.tar.gz --directory $HOME/.tart/vms/macOS_240417
+```
+
+  </TabItem>
+</Tabs>
+
 It may take a little to complete. Be patient and wait return of command.
 
 You can track progress of extraction by monitoring VM folder size.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 du -sh $HOME/.tart/vms/macOS_240306
 ```
 
+ </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+du -sh $HOME/.tart/vms/macOS_240417
+```
+
+  </TabItem>
+</Tabs>
+
 ### Download Xcode Images
 
 Download Xcode images from the Appcircle bucket. They are disk images for each Xcode version archived in a package.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240306.tar.gz
 ```
+
+ </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240417.tar.gz
+```
+
+  </TabItem>
+</Tabs>
 
 If you encounter network interruption, just run the same command again. It should continue download for remaining part. It will result in saving both time and bandwidth.
 
@@ -174,15 +285,43 @@ If you encounter network interruption, just run the same command again. It shoul
 
 **Note:** You can check the integrity of downloaded file by comparing the MD5 checksum.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 md5 xcodes_240306.tar.gz
 ```
 
+ </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+md5 xcodes_240417.tar.gz
+```
+
+  </TabItem>
+</Tabs>
+
 After a couple of minutes later you should see the output below.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 MD5 (xcodes_240306.tar.gz) = 4df051e11b6c0b8670cd9b82928dfab2
 ```
+
+ </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+MD5 (xcodes_240417.tar.gz) = 853146ed81cae1686b27d44c603885c7
+```
+
+  </TabItem>
+</Tabs>
 
 ---
 
@@ -194,21 +333,56 @@ mkdir -p $HOME/images
 
 Extract archive into the folder.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 tar -zxf xcodes_240306.tar.gz --directory $HOME/images
 ```
+
+ </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+tar -zxf xcodes_240417.tar.gz --directory $HOME/images
+```
+
+  </TabItem>
+</Tabs>
 
 It may take a little to complete. Be patient and wait return of command.
 
 ---
 
-**Note:** This macOS VM image contains the same tools as in the "Default M1 Pool" in Appcircle Cloud. It's the same image that's used for the Sonoma (`14.1`) stack and comes with the Xcode versions below:
+<Tabs groupId="macos-image">
 
-- `15.3.x`
-- `15.2.x`
-- `15.1.x`
-- `15.0.x`
-- `14.3.x`
+  <TabItem value="240306" label="240306" default>
+
+**Note:** This macOS VM image is the Sonoma (`14.1`) stack and comes with the Xcode versions below:
+
+> - `15.3.x`
+> - `15.2.x`
+> - `15.1.x`
+> - `15.0.x`
+> - `14.3.x`
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+**Note:** This macOS VM image contains the same tools as in the `latest` "Default M1 Pool" in Appcircle Cloud.
+
+It's the same image that's used for the `latest` Sonoma (`14.1`) stack and comes with the Xcode versions below:
+
+> - `15.4.x`
+> - `15.3.x`
+> - `15.2.x`
+> - `15.1.x`
+> - `15.0.x`
+> - `14.3.x`
+
+  </TabItem>
+</Tabs>
 
 In order to keep free disk space sufficient for build pipelines, we're packaging the latest and most frequently used Xcode versions. But you can also install other Xcode versions yourself if required.
 
@@ -233,9 +407,25 @@ If you don't need the latest Xcode and you want to run an older version of the m
 
 Apple's virtualization framework allows us to run up to two macOS VMs on host.
 
+:::caution
+
+If you have installed the macOS VM image previously and you're currently trying to upgrade your self-hosted runner environment to another release, first [stop](#stop-vm) the runners if they're online.
+
+Since the below steps will create new `vm01` and `vm02` from the base image, you should also cleanup the current ones using `tart delete` command.
+
+```bash
+tart delete vm01
+```
+
+```bash
+tart delete vm02
+```
+
+:::
+
 Each runner must register to the self-hosted Appcircle server with a unique name and configuration. So we will need two VM base images.
 
-When you list VMs with `tart list`, you should see our extracted VM image in list.
+When you list VMs with `tart list` command, you should see our extracted VM image in list.
 
 In the steps below, we will create 2 base images named vm01 and vm02.
 
@@ -245,16 +435,25 @@ The `vm01` base image is derived from our base image, and subsequently, the `vm0
 This approach eliminates the need to redo all the configurations applied to `vm01` when setting up `vm02`, ensuring efficiency and consistency across both virtual machines.
 :::
 
-```txt
-Source Name         Size
-local  macOS_240306 167
-```
-
 Create VM image for runner1.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 tart clone macOS_240306 vm01
 ```
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+tart clone macOS_240417 vm01
+```
+
+  </TabItem>
+</Tabs>
 
 In docker terminology, `vm01` and `vm02` will be our docker images. We will configure them separately, persist our changes and then create containers to execute build pipelines. On every build, fresh containers will be used for both runners.
 
@@ -264,6 +463,10 @@ In docker terminology, `vm01` and `vm02` will be our docker images. We will conf
 
 Start runner1 VM image for configuration.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.14.3.dmg:ro \
@@ -272,6 +475,22 @@ screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro
 ```
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+screen -d -m tart run vm01 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+</Tabs>
 
 SSH login into running macOS VM.
 
@@ -472,10 +691,16 @@ Runner will register to server defined in `ASPNETCORE_BASE_API_URL` and take bui
 
 The latest macOS VM image,`macOS_240221` or later, has the ASPNETCORE_NOSHUTDOWN setting as `false` by default and has no pre-defined ASPNETCORE_BASE_API_URL setting in the `appsettings.json` file.
 
-So, only modifying the ASPNETCORE_BASE_API_URL value with the following command should be enough for the self-hosted runner configuration.
+So, if you did not upgrade the packaged self-hosted runner at [previous steps](#1-check-the-runner-version) above, only modifying the ASPNETCORE_BASE_API_URL value with the following command should be enough for the self-hosted runner configuration.
 
 ```bash
 echo "$(jq '.ASPNETCORE_BASE_API_URL="https://api.test-appcircle.tool.zb/build/v1"' appsettings.json)" > appsettings.json
+```
+
+If you upgraded the self-hosted runner, you must also modify the ASPNETCORE_NOSHUTDOWN setting as well.
+
+```bash
+echo "$(jq '.ASPNETCORE_NOSHUTDOWN="false"' appsettings.json)" > appsettings.json
 ```
 
 :::
@@ -524,6 +749,10 @@ tart clone vm01 vm02
 
 Start runner2 image for configuration.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 screen -d -m tart run vm02 --no-graphics \
   --disk=$HOME/images/xcode.14.3.dmg:ro \
@@ -532,6 +761,22 @@ screen -d -m tart run vm02 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro
 ```
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+screen -d -m tart run vm02 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+</Tabs>
 
 SSH login into running macOS VM.
 
@@ -547,7 +792,7 @@ Refer to the [Configure Runner Service](#4-configure-runner-service) for detaile
 
 After shutdown, we're ready to run instances from `vm01` and `vm02` base VM images.
 
-At this stage your VM list returned by `tart list` should be like below.
+At this stage, your VM list returned by `tart list` might be like below, according to your preferred macOS VM image version.
 
 ```txt
 Source Name         Size
@@ -580,17 +825,47 @@ Download the script into runner folders you created and make script executable.
 
 For "runner1" use below commands.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.3.sh && \
 chmod u+x $HOME/runner1/run.sh
 ```
 
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
+chmod u+x $HOME/runner1/run.sh
+```
+
+  </TabItem>
+</Tabs>
+
 For "runner2" use below commands.
+
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
 
 ```bash
 curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.3.sh && \
 chmod u+x $HOME/runner2/run.sh
 ```
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
+chmod u+x $HOME/runner2/run.sh
+```
+
+  </TabItem>
+</Tabs>
 
 :::caution
 With new versions of the macOS VM image, we're also constantly updating the `run.sh` tool for fixes and improvements.
@@ -714,6 +989,10 @@ Steps, that we need to take, are technically similar as in [Create Base Images](
 - Stop all online runners as explained in [Stop VM](#stop-vm) section.
 - Run `vm01` base image.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.14.3.dmg:ro \
@@ -722,6 +1001,22 @@ screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro
 ```
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+screen -d -m tart run vm01 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+</Tabs>
 
 - SSH into `vm01`.
 
@@ -733,6 +1028,10 @@ ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm01)
 - Shutdown `vm01`.
 - Run `vm02` base image.
 
+<Tabs groupId="macos-image">
+
+  <TabItem value="240306" label="240306" default>
+
 ```bash
 screen -d -m tart run vm02 --no-graphics \
   --disk=$HOME/images/xcode.14.3.dmg:ro \
@@ -741,6 +1040,22 @@ screen -d -m tart run vm02 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro
 ```
+
+  </TabItem>
+  <TabItem value="240417" label="240417">
+
+```bash
+screen -d -m tart run vm02 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+</Tabs>
 
 - SSH into `vm02`.
 


### PR DESCRIPTION
`15.4.x` was added to the Xcode list, and macOS VM image documentation was improved to have multiple image versions.