### PR TITLE
BE-2904 Update iOS build infra docs with Xcode 15.4 RC

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -41,6 +41,31 @@ Our macOS build agents have Xcode versions 15.4.x, 15.3.x, 15.2.x, 15.1.x, 15.0.
 Xcode `14.3.x` or higher Xcode versions require a Mac running macOS Ventura 13.0 or later.
 :::
 
+The "Default M1 Pool" macOS **Sonoma** (`14.1`) stack has the Xcode versions below:
+
+| Version | Build |
+| ------- | ----- |
+| 15.4 RC 1 | `15F31c` |
+| 15.3 | `15E204a` |
+| 15.2 | `15C500b` |
+| 15.1 | `15C65` |
+| 15.0.1 | `15A507` |
+| 14.3.1 | `14E300c` |
+
+The "Default M1 Pool" macOS **Monterey** (`12.5.1`) stack has the Xcode versions below:
+
+| Version | Build |
+| ------- | ----- |
+| 14.2 | `14C18` |
+| 14.1 | `14B47b` |
+| 14.0.1 | `14A400` |
+| 13.4 | `13F17a` |
+| 13.3 | `13E113` |
+| 13.2.1 | `13C100` |
+| 13.1 | `13A1030d` |
+| 13.0 | `13A233` |
+| 12.5.1 | `12E507` |
+
 ## iOS Build Agent Stacks
 
 There are many pre-installed packages on virtual machines. You can get a full list of pre-installed packages by running Bash commands in "custom script" steps.

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -140,10 +140,10 @@ curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240417.tar.gz
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240509.tar.gz
 ```
 
   </TabItem>
@@ -164,10 +164,10 @@ md5 macOS_240306.tar.gz
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-md5 macOS_240417.tar.gz
+md5 macOS_240509.tar.gz
 ```
 
   </TabItem>
@@ -184,10 +184,10 @@ MD5 (macOS_240306.tar.gz) = 084a9221075ed5453aceba6a3438b134
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-MD5 (macOS_240417.tar.gz) = 781b29c712927a664d09e605524f3ed6
+MD5 (macOS_240509.tar.gz) = 4de4666f8e68afbff8a55a144aabe256
 ```
 
   </TabItem>
@@ -206,10 +206,10 @@ mkdir -p $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-mkdir -p $HOME/.tart/vms/macOS_240417
+mkdir -p $HOME/.tart/vms/macOS_240509
 ```
 
   </TabItem>
@@ -226,10 +226,10 @@ tar -zxf macOS_240306.tar.gz --directory $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-tar -zxf macOS_240417.tar.gz --directory $HOME/.tart/vms/macOS_240417
+tar -zxf macOS_240509.tar.gz --directory $HOME/.tart/vms/macOS_240509
 ```
 
   </TabItem>
@@ -248,10 +248,10 @@ du -sh $HOME/.tart/vms/macOS_240306
 ```
 
  </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-du -sh $HOME/.tart/vms/macOS_240417
+du -sh $HOME/.tart/vms/macOS_240509
 ```
 
   </TabItem>
@@ -270,10 +270,10 @@ curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/
 ```
 
  </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240417.tar.gz
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240509.tar.gz
 ```
 
   </TabItem>
@@ -294,10 +294,10 @@ md5 xcodes_240306.tar.gz
 ```
 
  </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-md5 xcodes_240417.tar.gz
+md5 xcodes_240509.tar.gz
 ```
 
   </TabItem>
@@ -314,10 +314,10 @@ MD5 (xcodes_240306.tar.gz) = 4df051e11b6c0b8670cd9b82928dfab2
 ```
 
  </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-MD5 (xcodes_240417.tar.gz) = 853146ed81cae1686b27d44c603885c7
+MD5 (xcodes_240509.tar.gz) = 230b697351739410ab4ec537b09999ab
 ```
 
   </TabItem>
@@ -342,10 +342,10 @@ tar -zxf xcodes_240306.tar.gz --directory $HOME/images
 ```
 
  </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-tar -zxf xcodes_240417.tar.gz --directory $HOME/images
+tar -zxf xcodes_240509.tar.gz --directory $HOME/images
 ```
 
   </TabItem>
@@ -368,7 +368,7 @@ It may take a little to complete. Be patient and wait return of command.
 > - `14.3.x`
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 **Note:** This macOS VM image contains the same tools as in the `latest` "Default M1 Pool" in Appcircle Cloud.
 
@@ -446,10 +446,10 @@ tart clone macOS_240306 vm01
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
-tart clone macOS_240417 vm01
+tart clone macOS_240509 vm01
 ```
 
   </TabItem>
@@ -477,7 +477,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -763,7 +763,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -835,7 +835,7 @@ chmod u+x $HOME/runner1/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
 curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
@@ -857,7 +857,7 @@ chmod u+x $HOME/runner2/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
 curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
@@ -1003,7 +1003,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -1042,7 +1042,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240417" label="240417">
+  <TabItem value="240509" label="240509">
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \


### PR DESCRIPTION
The iOS Build Infra page now has a table of actual Xcode versions with build numbers, just like other CI/CD providers.
- https://twitter.com/polpielladev/status/1765739368814387688

macOS image version `240417` (Xcode 15.4 beta 1) was replaced by `240509` (Xcode 15.4 RC 1).