### PR TITLE
Add Tart trademark note

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -46,7 +46,7 @@ brew --version
 
 ### 2. Install Tart
 
-Tap Appcircle repository and install tart.
+Tap Appcircle repository and install `tart` (Tart is a registered trademark of Cirrus Labs, Inc.).
 
 ```bash
 brew tap appcircleio/cli


### PR DESCRIPTION
I'm creating this PR on behalf of Cirrus Labs, Inc. (the authors of [Tart](https://github.com/cirruslabs/tart)). We really appreciate that you found Tart useful and it helps your users.

We found that documentation around Tart on https://docs.appcircle.io/ might be misleading and one can affiliate Tart with Appcircle. To clear things up we propose to add a note that [Tart is a registered trademark of Cirrus Labs, Inc](https://tsdr.uspto.gov/#caseNumber=97892370&caseSearchType=US_APPLICATION&caseType=DEFAULT&searchType=statusSearch).