### PR TITLE
Feature/BN-3101 Docs Update - Publish App Version Upload with different bundleId

### DIFF
--- a/docs/publish-module/binary-management/index.md
+++ b/docs/publish-module/binary-management/index.md
@@ -19,6 +19,14 @@ You can then upload the application by clicking on the **Add Version** button on
 
 When the upload is completed successfully, the relevant application version will appear in the list.
 
+:::caution BUNDLE ID AND PACKAGE NAME MUST BE UNIQUE
+To maintain consistency, the uploading of iOS app versions with different Bundle IDs under the same Publish Profile is prohibited. All app versions are mandated to share the the same Bundle ID within the Publish Profile. 
+
+Similarly, for Android Publish Profiles, all app versions must exhibit identical Package Names within the Android Publish Profile.
+
+The Bundle ID (iOS) and Package Name (Android) can be viewed beneath the Publish Profile name. Users can also verify this information by selecting the [Binary Information](https://docs.appcircle.io/publish-module/publish-information/binary-information) for an app version under actions menu.
+:::
+
 Afterwards, you can start submitting your application to the stores with the publish flow that you have configured.
 
 <Screenshot url='https://cdn.appcircle.io/docs/assets/publish-version-list.png' />


### PR DESCRIPTION
Added caution note inside binary management page regarding bundle id and package name.