### PR TITLE
BE-3711 Xcode 15.4 final release updates

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -45,7 +45,7 @@ The "Default M1 Pool" macOS **Sonoma** (`14.1`) stack has the Xcode versions bel
 
 | Version | Build |
 | ------- | ----- |
-| 15.4 RC 1 | `15F31c` |
+| 15.4 | `15F31d` |
 | 15.3 | `15E204a` |
 | 15.2 | `15C500b` |
 | 15.1 | `15C65` |

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -195,7 +195,7 @@ MD5 (macOS_240306.tar.gz) = 084a9221075ed5453aceba6a3438b134
   <TabItem value="240514" llabel="240514" default>
 
 ```bash
-MD5 (macOS_240514.tar.gz) = 4de4666f8e68afbff8a55a144aabe256
+MD5 (macOS_240514.tar.gz) = 8524abc65668a084589e79f214a9b281
 ```
 
   </TabItem>
@@ -325,7 +325,7 @@ MD5 (xcodes_240306.tar.gz) = 4df051e11b6c0b8670cd9b82928dfab2
   <TabItem value="240514" llabel="240514" default>
 
 ```bash
-MD5 (xcodes_240514.tar.gz) = 230b697351739410ab4ec537b09999ab
+MD5 (xcodes_240514.tar.gz) = e3edc40c9b6dda91530d8a1f8cf456bc
 ```
 
   </TabItem>

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -148,7 +148,7 @@ curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240514.tar.gz
@@ -172,7 +172,7 @@ md5 macOS_240306.tar.gz
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 md5 macOS_240514.tar.gz
@@ -192,7 +192,7 @@ MD5 (macOS_240306.tar.gz) = 084a9221075ed5453aceba6a3438b134
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 MD5 (macOS_240514.tar.gz) = 8524abc65668a084589e79f214a9b281
@@ -214,7 +214,7 @@ mkdir -p $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 mkdir -p $HOME/.tart/vms/macOS_240514
@@ -234,7 +234,7 @@ tar -zxf macOS_240306.tar.gz --directory $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 tar -zxf macOS_240514.tar.gz --directory $HOME/.tart/vms/macOS_240514
@@ -256,7 +256,7 @@ du -sh $HOME/.tart/vms/macOS_240306
 ```
 
  </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 du -sh $HOME/.tart/vms/macOS_240514
@@ -278,7 +278,7 @@ curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/
 ```
 
  </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240514.tar.gz
@@ -302,7 +302,7 @@ md5 xcodes_240306.tar.gz
 ```
 
  </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 md5 xcodes_240514.tar.gz
@@ -322,7 +322,7 @@ MD5 (xcodes_240306.tar.gz) = 4df051e11b6c0b8670cd9b82928dfab2
 ```
 
  </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 MD5 (xcodes_240514.tar.gz) = e3edc40c9b6dda91530d8a1f8cf456bc
@@ -350,7 +350,7 @@ tar -zxf xcodes_240306.tar.gz --directory $HOME/images
 ```
 
  </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 tar -zxf xcodes_240514.tar.gz --directory $HOME/images
@@ -376,7 +376,7 @@ It may take a little to complete. Be patient and wait return of command.
 > - `14.3.x`
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 **Note:** This macOS VM image contains the same tools as in the `latest` "Default M1 Pool" in Appcircle Cloud.
 
@@ -424,7 +424,7 @@ nohup ./download-runner.sh "240306" &
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 curl -fsSL -O https://cdn.appcircle.io/self-hosted/download-runner.sh && \
@@ -500,7 +500,7 @@ tart clone macOS_240306 vm01
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 tart clone macOS_240514 vm01
@@ -531,7 +531,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -817,7 +817,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -889,7 +889,7 @@ chmod u+x $HOME/runner1/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
@@ -911,7 +911,7 @@ chmod u+x $HOME/runner2/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
@@ -1057,7 +1057,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -1096,7 +1096,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" llabel="240514" default>
+  <TabItem value="240514" label="240514" default>
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \

--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -141,17 +141,17 @@ Download macOS VM from Appcircle bucket.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240306.tar.gz
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240509.tar.gz
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240514.tar.gz
 ```
 
   </TabItem>
@@ -165,17 +165,17 @@ If you encounter network interruption, just run the same command again. It shoul
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 md5 macOS_240306.tar.gz
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-md5 macOS_240509.tar.gz
+md5 macOS_240514.tar.gz
 ```
 
   </TabItem>
@@ -185,17 +185,17 @@ After a couple of minutes later you should see the output below.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 MD5 (macOS_240306.tar.gz) = 084a9221075ed5453aceba6a3438b134
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-MD5 (macOS_240509.tar.gz) = 4de4666f8e68afbff8a55a144aabe256
+MD5 (macOS_240514.tar.gz) = 4de4666f8e68afbff8a55a144aabe256
 ```
 
   </TabItem>
@@ -207,17 +207,17 @@ Create folder for VM.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 mkdir -p $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-mkdir -p $HOME/.tart/vms/macOS_240509
+mkdir -p $HOME/.tart/vms/macOS_240514
 ```
 
   </TabItem>
@@ -227,17 +227,17 @@ Extract archive into VMs folder.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 tar -zxf macOS_240306.tar.gz --directory $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-tar -zxf macOS_240509.tar.gz --directory $HOME/.tart/vms/macOS_240509
+tar -zxf macOS_240514.tar.gz --directory $HOME/.tart/vms/macOS_240514
 ```
 
   </TabItem>
@@ -249,17 +249,17 @@ You can track progress of extraction by monitoring VM folder size.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 du -sh $HOME/.tart/vms/macOS_240306
 ```
 
  </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-du -sh $HOME/.tart/vms/macOS_240509
+du -sh $HOME/.tart/vms/macOS_240514
 ```
 
   </TabItem>
@@ -271,17 +271,17 @@ Download Xcode images from the Appcircle bucket. They are disk images for each X
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240306.tar.gz
 ```
 
  </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240509.tar.gz
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240514.tar.gz
 ```
 
   </TabItem>
@@ -295,17 +295,17 @@ If you encounter network interruption, just run the same command again. It shoul
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 md5 xcodes_240306.tar.gz
 ```
 
  </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-md5 xcodes_240509.tar.gz
+md5 xcodes_240514.tar.gz
 ```
 
   </TabItem>
@@ -315,17 +315,17 @@ After a couple of minutes later you should see the output below.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 MD5 (xcodes_240306.tar.gz) = 4df051e11b6c0b8670cd9b82928dfab2
 ```
 
  </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-MD5 (xcodes_240509.tar.gz) = 230b697351739410ab4ec537b09999ab
+MD5 (xcodes_240514.tar.gz) = 230b697351739410ab4ec537b09999ab
 ```
 
   </TabItem>
@@ -343,17 +343,17 @@ Extract archive into the folder.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 tar -zxf xcodes_240306.tar.gz --directory $HOME/images
 ```
 
  </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-tar -zxf xcodes_240509.tar.gz --directory $HOME/images
+tar -zxf xcodes_240514.tar.gz --directory $HOME/images
 ```
 
   </TabItem>
@@ -365,7 +365,7 @@ It may take a little to complete. Be patient and wait return of command.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 **Note:** This macOS VM image is the Sonoma (`14.1`) stack and comes with the Xcode versions below:
 
@@ -376,7 +376,7 @@ It may take a little to complete. Be patient and wait return of command.
 > - `14.3.x`
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 **Note:** This macOS VM image contains the same tools as in the `latest` "Default M1 Pool" in Appcircle Cloud.
 
@@ -415,7 +415,7 @@ To download and extract the Appcircle runner VM and Xcode images in the backgrou
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 curl -fsSL -O https://cdn.appcircle.io/self-hosted/download-runner.sh && \
@@ -424,12 +424,12 @@ nohup ./download-runner.sh "240306" &
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 curl -fsSL -O https://cdn.appcircle.io/self-hosted/download-runner.sh && \
 chmod +x download-runner.sh && \
-nohup ./download-runner.sh "240509" &
+nohup ./download-runner.sh "240514" &
 ```
 
   </TabItem>
@@ -493,17 +493,17 @@ Create VM image for runner1.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 tart clone macOS_240306 vm01
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
-tart clone macOS_240509 vm01
+tart clone macOS_240514 vm01
 ```
 
   </TabItem>
@@ -519,7 +519,7 @@ Start runner1 VM image for configuration.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -531,7 +531,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -805,7 +805,7 @@ Start runner2 image for configuration.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -817,7 +817,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -881,7 +881,7 @@ For "runner1" use below commands.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.3.sh && \
@@ -889,7 +889,7 @@ chmod u+x $HOME/runner1/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
@@ -903,7 +903,7 @@ For "runner2" use below commands.
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.3.sh && \
@@ -911,7 +911,7 @@ chmod u+x $HOME/runner2/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
@@ -1045,7 +1045,7 @@ Steps, that we need to take, are technically similar as in [Create Base Images](
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -1057,7 +1057,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -1084,7 +1084,7 @@ ssh -o StrictHostKeyChecking=no appcircle@$(tart ip vm01)
 
 <Tabs groupId="macos-image">
 
-  <TabItem value="240306" label="240306" default>
+  <TabItem value="240306" label="240306">
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -1096,7 +1096,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240509" label="240509">
+  <TabItem value="240514" llabel="240514" default>
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \


### PR DESCRIPTION
We replaced the release candidate with the latest release of Xcode. So, 
- iOS build infrastructure page got update. (Xcode 15.4)
- macOS VM image version bumped to `240514`. (default)