### PR TITLE
#BE-3857 Docs Update - Resign and Publish history Merging

### DIFF
--- a/docs/publish-module/publish-information/delete.md
+++ b/docs/publish-module/publish-information/delete.md
@@ -11,7 +11,7 @@ import Screenshot from '@site/src/components/Screenshot';
 
 The "Delete" function in the Publish module allows users to remove specific versions of an app from the module. This action does not affect any versions of the app that have been submitted to app stores; it only removes the version from Appcircle's Publish module.
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/publish-delete.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub6.png' />
 
 ## Steps to Delete a Build Version
 

--- a/docs/publish-module/publish-information/download.md
+++ b/docs/publish-module/publish-information/download.md
@@ -11,7 +11,7 @@ import Screenshot from '@site/src/components/Screenshot';
 
 The "Download" function in the Publish module allows you to easily download the built application files, such as IPA for iOS or APK/AAB for Android, directly to your local system.
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/publish-download.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub3.png' />
 
 ## Steps to Download Your Binary
 

--- a/docs/publish-module/publish-information/history.md
+++ b/docs/publish-module/publish-information/history.md
@@ -1,28 +1,38 @@
 ---
-title: Publish History
-description: Learn how to access and review the Publish History in Appcircle
-tags: [publish history, publish module, publish information]
+title: History
+description: Learn how to access and review the History for Publish History and Resign History in Appcircle
+tags: [publish history, publish module, publish information, resign history, history]
 sidebar_position: 4
 ---
 
-# Publish History
+# History
 
 import Screenshot from '@site/src/components/Screenshot';
 import ContentRef from '@site/src/components/ContentRef';
 
+The History section has two parts: The Publish History and The Resign History.
+
 The Publish History section is a record of all the publishing actions that have been performed for different versions of an application. It serves as a log for tracking the deployment lifecycle of each release.
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/publish-history-button.png' />
+The Resign History section is a record of all the resign actions that have been performed within the Publish module for a specific app version.
+
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub4.png' />
 
 ## Overview
 
+Once you select the History section you can access both the Publish History and the Resign History.
+
 You can access the Publish History to gain insight into the sequence of events for each published version. It is an invaluable tool for auditing, troubleshooting, and understanding the timeline of version deployments.
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/publish-history-list.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub5.png' />
+
+You can also access the Resign History for an app version by navigating to it's tab to monitor the resign actions for that specific version.
+
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub9.png' />
 
 ### Accessing Publish History
 
-To view the Publish History, navigate to the corresponding section in the Publish module. This section lists all versions of the app along with the dates and times their publishing actions started.
+To view the Publish History, navigate to the History section in the Publish module. Once History is selected, The Publish History tab will be displayed by default. This section lists all versions of the app along with the dates and times their publishing actions started.
 
 ### Viewing Logs
 
@@ -56,3 +66,26 @@ Upon selecting a specific version, you will be presented with a detailed log. Th
 ---
 
 The Publish History is a key feature that provides transparency and traceability in the application deployment process. By regularly reviewing this section, you can ensure that your publish actions are performing as expected and maintain a high level of quality control over your release management process.
+
+### Accessing Resign History
+
+To view the Resign History, navigate to the History section in the Publish module, then simply select the Resign History tab.
+
+### Viewing Logs
+
+Each signing process will be listed for that binary. If you click on the displayed resign action , you can get more details about the process by seeing the logs.
+
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub9.png' />
+
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub10.png' />
+
+:::info
+
+You need the check the history of the original application that has been signed.
+
+:::
+
+<ContentRef
+url="/publish-module/publish-information/resign-binary">
+Read more about Resign Binary
+</ContentRef>

--- a/docs/publish-module/publish-information/index.md
+++ b/docs/publish-module/publish-information/index.md
@@ -12,7 +12,7 @@ import Screenshot from '@site/src/components/Screenshot';
 
 The Publish module provides users with several key actions to manage their application versions effectively. Below is an overview of each menu item and its function within the system:
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/2821-ios-publish-actions.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub1.png' />
 
 ## Publish Details
 
@@ -63,13 +63,17 @@ url="/publish-module/publish-information/download">
 Read more about Downloading Binaries
 </ContentRef>
 
-## Publish History
+## History
+
+The History has two sections: The Publish History and The Resign History.
 
 The Publish History gives users a chronological log of all publish actions taken for a specific version. It allows users to track and audit the deployment process over time, which can be crucial for compliance, troubleshooting, and historical analysis.
 
+The Resign History gives users a chronological log of all resign actions that was done within the Publish Module for a specific app version. 
+
 <ContentRef
-url="/publish-module/publish-information/publish-history">
-Read more about Publish History
+url="/publish-module/publish-information/history">
+Read more about History
 </ContentRef>
 
 ## Delete

--- a/docs/publish-module/publish-information/marking-release-candidates.md
+++ b/docs/publish-module/publish-information/marking-release-candidates.md
@@ -12,7 +12,7 @@ import ContentRef from '@site/src/components/ContentRef';
 
 Appcircle allows you to mark your app version as RC and designate any version as a **Release Candidate** with ease by simply selecting the desired app version and clicking on the **Mark as RC** button.
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/publish-mark-rc-button.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub2.png' />
 
 :::caution
 In order to execute a flow, it must be marked as a Release Candidate (RC). If it is not marked as RC, it cannot be executed.

--- a/docs/publish-module/publish-information/meta-data-information.md
+++ b/docs/publish-module/publish-information/meta-data-information.md
@@ -8,7 +8,7 @@ import Screenshot from '@site/src/components/Screenshot';
 
 # Metadata Information
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3667-meta-data-information-menu.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub7.png' />
 
 ## Overview
 

--- a/docs/publish-module/publish-information/resign-binary.md
+++ b/docs/publish-module/publish-information/resign-binary.md
@@ -12,7 +12,7 @@ The **Resign Binary** feature in Appcircle allows you to resign both iOS and And
 
 This feature streamlines the process of updating app distribution and security settings, ensuring that your applications can be quickly adapted to meet changing requirements or distribution strategies.
 
-<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3161-publish-resign-option.png' />
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3857-pub8.png' />
 
 ## Resign iOS Binary
 


### PR DESCRIPTION
Re-named Publish History sub-section to History. 

Publish and Resign History are now merged under History button. 

Updated screenshots throughout the Publish module documentations to have the latest History button. 

Also added additional information inside the History section.