### PR TITLE
BE-3958 Xcode 16.0 Beta 2

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -45,7 +45,7 @@ The "Default M1 Pool" macOS **Sonoma** (`14.5`) stack has the Xcode versions bel
 
 | Version | Build |
 | ------- | ----- |
-| 16.0 | `16A5171c` |
+| 16.0 | `16A5171r` |
 | 15.4 | `15F31d` |
 | 15.3 | `15E204a` |
 | 15.2 | `15C500b` |


### PR DESCRIPTION
Update the build number for the latest Xcode 16.0 in production.