### PR TITLE
Improve self-hosted Appcircle overview page

### DIFF
--- a/docs/self-hosted-appcircle/index.md
+++ b/docs/self-hosted-appcircle/index.md
@@ -11,16 +11,6 @@ Self-hosted Appcircle enables you to use your own systems and infrastructure for
 
 By this way, you can build and test your apps on your choice of architectures. You have full control over the build environment. You can also customize your Appcircle installation with various options.
 
-When we look at self-hosted Appcircle deployment as a whole, we will see below architecture in execution.
-
-<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3008-appcircle-topology.png' />
-
-To see the topology diagram in greater detail, click [here](https://cdn.appcircle.io/docs/assets/be-3008-appcircle-topology.png). It will open the diagram in new browser tab.
-
-:::tip
-You can see all external network access details on the [Network Access](/self-hosted-appcircle/configure-server/integrations-and-access/network-access) page.
-:::
-
 With the help of self-hosted runners as connected agents, you can have whole Appcircle in your own infrastructure and use all Appcircle features in your private cloud without any limitations.
 
 Self-hosted Appcircle section in here, gives you detailed information about only server-side components installation and other related operations. For details about self-hosted runner concept, see [Self-hosted Runner](/self-hosted-appcircle/self-hosted-runner) section in docs.
@@ -31,6 +21,20 @@ The only requirement for using self-hosted Appcircle is to be in `enterprise` pl
 
 See [pricing](https://appcircle.io/pricing) and feature comparison table for details.
 
+:::
+
+## Appcircle Standalone Architecture
+
+We generally recommend a standalone approach by deploying a single node environment for the Appcircle server to reduce the complexity a little further.
+
+When we look at self-hosted Appcircle deployment as a whole, we will see below architecture in execution for a basic installation.
+
+<Screenshot url='https://cdn.appcircle.io/docs/assets/be-3008-appcircle-topology.png' />
+
+To see the topology diagram in greater detail, click [here](https://cdn.appcircle.io/docs/assets/be-3008-appcircle-topology.png). It will open the diagram in new browser tab.
+
+:::tip
+You can see all external network access details on the [Network Access](/self-hosted-appcircle/configure-server/integrations-and-access/network-access) page.
 :::
 
 ## Appcircle DMZ Architecture


### PR DESCRIPTION
In order to clarify that the Appcircle has two types of architecture, we added a title for the previous basic architecture.

Common parts are moved to the "overview" section and added an extra explanation to the "standalone" architecture.