### PR TITLE
BE-4420 Update Xcode 16.0 RC 1

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -46,7 +46,7 @@ The "Default M1 Pool" macOS **Sonoma** (`14.5`) stack has the Xcode versions bel
 | Version | Build |
 | ------- | ----- |
 | 16.1 | `16B5001e` |
-| 16.0 | `16A5230g` |
+| 16.0 | `16A242` |
 | 15.4 | `15F31d` |
 | 15.3 | `15E204a` |
 | 15.2 | `15C500b` |


### PR DESCRIPTION
Update the build number for the latest Xcode 16.0 in production.