### PR TITLE
BE-4394 Mark need help section to exclude

### DIFF
--- a/docs/_need-help.mdx
+++ b/docs/_need-help.mdx
@@ -1,5 +1,5 @@
 ### Need help?
 
-Get help from Appcircle's support team, or see how others are using Appcircle by joining our Slack Channel.
+<p class="need-help">Get help from Appcircle's support team, or see how others are using Appcircle by joining our Slack Channel.</p>
 
-https://join.slack.com/t/appcircleio/signup
+<p class="need-help">https://join.slack.com/t/appcircleio/signup</p>


### PR DESCRIPTION
I added some filtering to the Algolia record extractor to remove unnecessary (noisy) records to be indexed. So, the user can reach more relevant results while searching.

Within this PR, I marked parts of the **Need Help** section in order to exclude them on the Algolia side. By this way, it can be identified from other searchable contexts.

Currently, the "need-help" CSS class is a non-existing class. It can also be used to style the relevant parts in the future. (optional)