### PR TITLE
BE-4479 Update macOS VM image documents for latest Xcode

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -149,10 +149,17 @@ curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240514.tar.gz
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/macOS_240918.tar.gz
 ```
 
   </TabItem>
@@ -173,13 +180,21 @@ md5 macOS_240306.tar.gz
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 md5 macOS_240514.tar.gz
 ```
 
   </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+md5 macOS_240918.tar.gz
+```
+
+  </TabItem>
+
 </Tabs>
 
 After a couple of minutes later you should see the output below.
@@ -193,10 +208,17 @@ MD5 (macOS_240306.tar.gz) = 084a9221075ed5453aceba6a3438b134
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 MD5 (macOS_240514.tar.gz) = 8524abc65668a084589e79f214a9b281
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+MD5 (macOS_240918.tar.gz) = aeb6ff4b655b04fa47fb45e2caf09792
 ```
 
   </TabItem>
@@ -215,10 +237,17 @@ mkdir -p $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 mkdir -p $HOME/.tart/vms/macOS_240514
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+mkdir -p $HOME/.tart/vms/macOS_240918
 ```
 
   </TabItem>
@@ -235,10 +264,17 @@ tar -zxf macOS_240306.tar.gz --directory $HOME/.tart/vms/macOS_240306
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 tar -zxf macOS_240514.tar.gz --directory $HOME/.tart/vms/macOS_240514
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+tar -zxf macOS_240918.tar.gz --directory $HOME/.tart/vms/macOS_240918
 ```
 
   </TabItem>
@@ -257,10 +293,17 @@ du -sh $HOME/.tart/vms/macOS_240306
 ```
 
  </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 du -sh $HOME/.tart/vms/macOS_240514
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+du -sh $HOME/.tart/vms/macOS_240918
 ```
 
   </TabItem>
@@ -279,10 +322,17 @@ curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/
 ```
 
  </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240514.tar.gz
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+curl -L -O -C - https://storage.googleapis.com/appcircle-dev-common/self-hosted/xcodes_240918.tar.gz
 ```
 
   </TabItem>
@@ -303,10 +353,17 @@ md5 xcodes_240306.tar.gz
 ```
 
  </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 md5 xcodes_240514.tar.gz
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+md5 xcodes_240918.tar.gz
 ```
 
   </TabItem>
@@ -323,10 +380,17 @@ MD5 (xcodes_240306.tar.gz) = 4df051e11b6c0b8670cd9b82928dfab2
 ```
 
  </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 MD5 (xcodes_240514.tar.gz) = e3edc40c9b6dda91530d8a1f8cf456bc
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+MD5 (xcodes_240918.tar.gz) = bb26c0070bbd1a8ed23fe59b87f0a144
 ```
 
   </TabItem>
@@ -351,10 +415,17 @@ tar -zxf xcodes_240306.tar.gz --directory $HOME/images
 ```
 
  </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 tar -zxf xcodes_240514.tar.gz --directory $HOME/images
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+tar -zxf xcodes_240918.tar.gz --directory $HOME/images
 ```
 
   </TabItem>
@@ -377,12 +448,24 @@ It may take a little to complete. Be patient and wait return of command.
 > - `14.3.x`
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
-**Note:** This macOS VM image contains the same tools as in the `latest` "Default M1 Pool" in Appcircle Cloud.
+**Note:** This macOS VM image is the Sonoma (`14.1`) stack and comes with the Xcode versions below:
 
-It's the same image that's used for the `latest` Sonoma (`14.1`) stack and comes with the Xcode versions below:
+> - `15.4.x`
+> - `15.3.x`
+> - `15.2.x`
+> - `15.1.x`
+> - `15.0.x`
+> - `14.3.x`
 
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+**Note:** This macOS VM image is the Sonoma (`14.5`) stack and comes with the Xcode versions below:
+
+> - `16.1.x`
+> - `16.0.x`
 > - `15.4.x`
 > - `15.3.x`
 > - `15.2.x`
@@ -403,7 +486,7 @@ You can find more information about the build infrastructure in the documents be
 :::caution
 We're constantly bumping the VM macOS version according to Xcode requirements.
 
-So the latest VM image,`macOS_230921` or later, includes Ventura `13.5.2` or Sonoma `14.1` pre-installed and needs at least a Ventura host to run.
+So the latest VM image,`macOS_230921` or later, includes Ventura `13.5.2` or Sonoma `14.x` pre-installed and needs at least a Ventura host to run.
 
 It doesn't support running on older hosts like Monterey, Big Sur, etc.
 
@@ -425,12 +508,21 @@ nohup ./download-runner.sh "240306" &
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 curl -fsSL -O https://cdn.appcircle.io/self-hosted/download-runner.sh && \
 chmod +x download-runner.sh && \
 nohup ./download-runner.sh "240514" &
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+curl -fsSL -O https://cdn.appcircle.io/self-hosted/download-runner.sh && \
+chmod +x download-runner.sh && \
+nohup ./download-runner.sh "240918" &
 ```
 
   </TabItem>
@@ -501,10 +593,17 @@ tart clone macOS_240306 vm01
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 tart clone macOS_240514 vm01
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+tart clone macOS_240918 vm01
 ```
 
   </TabItem>
@@ -526,7 +625,6 @@ If you're freshly creating the base VMs, you can ignore this warning. However, i
 
 :::
 
-
 #### Configure Runner 1
 
 Start runner1 VM image for configuration.
@@ -545,7 +643,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -555,6 +653,21 @@ screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro \
   --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+screen -d -m tart run vm01 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro \
+  --disk=$HOME/images/xcode.16.0.dmg:ro \
+  --disk=$HOME/images/xcode.16.1.dmg:ro 
 ```
 
   </TabItem>
@@ -839,7 +952,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -849,6 +962,21 @@ screen -d -m tart run vm02 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro \
   --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+screen -d -m tart run vm02 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro \
+  --disk=$HOME/images/xcode.16.0.dmg:ro \
+  --disk=$HOME/images/xcode.16.1.dmg:ro
 ```
 
   </TabItem>
@@ -911,10 +1039,18 @@ chmod u+x $HOME/runner1/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
+chmod u+x $HOME/runner1/run.sh
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+curl -L -o $HOME/runner1/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.5.sh && \
 chmod u+x $HOME/runner1/run.sh
 ```
 
@@ -933,10 +1069,18 @@ chmod u+x $HOME/runner2/run.sh
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.4.sh && \
+chmod u+x $HOME/runner2/run.sh
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+curl -L -o $HOME/runner2/run.sh https://storage.googleapis.com/appcircle-dev-common/self-hosted/run-1.0.5.sh && \
 chmod u+x $HOME/runner2/run.sh
 ```
 
@@ -1079,7 +1223,7 @@ screen -d -m tart run vm01 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 screen -d -m tart run vm01 --no-graphics \
@@ -1089,6 +1233,21 @@ screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro \
   --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+screen -d -m tart run vm01 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro \
+  --disk=$HOME/images/xcode.16.0.dmg:ro \
+  --disk=$HOME/images/xcode.16.1.dmg:ro
 ```
 
   </TabItem>
@@ -1118,7 +1277,7 @@ screen -d -m tart run vm02 --no-graphics \
 ```
 
   </TabItem>
-  <TabItem value="240514" label="240514" default>
+  <TabItem value="240514" label="240514">
 
 ```bash
 screen -d -m tart run vm02 --no-graphics \
@@ -1128,6 +1287,21 @@ screen -d -m tart run vm02 --no-graphics \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro \
   --disk=$HOME/images/xcode.15.4.dmg:ro
+```
+
+  </TabItem>
+  <TabItem value="240918" label="240918" default>
+
+```bash
+screen -d -m tart run vm02 --no-graphics \
+  --disk=$HOME/images/xcode.14.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.0.dmg:ro \
+  --disk=$HOME/images/xcode.15.1.dmg:ro \
+  --disk=$HOME/images/xcode.15.2.dmg:ro \
+  --disk=$HOME/images/xcode.15.3.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro \
+  --disk=$HOME/images/xcode.16.0.dmg:ro \
+  --disk=$HOME/images/xcode.16.1.dmg:ro
 ```
 
   </TabItem>
@@ -1280,7 +1454,6 @@ Below step in [update base images](#update-base-images) section,
 should be like this in this case.
 
 > 2- Run `vm01` base image. `screen -d -m tart run vm01`
-
 
 ### Deleting Xcode simulator runtimes to create free disk space
 


### PR DESCRIPTION
I added a new tab that has the `latest` macOS VM image that's used in Appcircle Cloud.