### PR TITLE
BE-4622 Update Xcode 16.1 RC 1

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -45,7 +45,7 @@ The "Default M1 Pool" macOS **Sonoma** (`14.5`) stack has the Xcode versions bel
 
 | Version | Build |
 | ------- | ----- |
-| 16.1 | `16B5029d` |
+| 16.1 | `16B40` |
 | 16.0 | `16A242d` |
 | 15.4 | `15F31d` |
 | 15.3 | `15E204a` |


### PR DESCRIPTION
Update the build number for the latest Xcode 16.1 in production.