### PR TITLE
Self-hosted server hotfix release 3.23.2

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/runner-vm-setup.md
@@ -670,7 +670,7 @@ screen -d -m tart run vm01 --no-graphics \
   --disk=$HOME/images/xcode.15.1.dmg:ro \
   --disk=$HOME/images/xcode.15.2.dmg:ro \
   --disk=$HOME/images/xcode.15.3.dmg:ro \
-  --disk=$HOME/images/xcode.15.4.dmg:ro \
+  --disk=$HOME/images/xcode.15.4.dmg:ro \
   --disk=$HOME/images/xcode.16.0.dmg:ro \
   --disk=$HOME/images/xcode.16.1.dmg:ro
 ```

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -89,6 +89,7 @@ Below is the version history of the self-hosted Appcircle server. This table hel
         
         | Version   | Release Date |
         |-----------|--------------|
+        |  3.23.2  | 04/12/2024   |
         | [3.23.1]  | 19/11/2024   |
         | [3.23.0]  |     -        |
         | [3.22.1]  | 23/10/2024   |

--- a/docs/self-hosted-appcircle/update.md
+++ b/docs/self-hosted-appcircle/update.md
@@ -89,7 +89,7 @@ Below is the version history of the self-hosted Appcircle server. This table hel
         
         | Version   | Release Date |
         |-----------|--------------|
-        |  3.23.2  | 04/12/2024   |
+        |  3.23.2   | 04/12/2024   |
         | [3.23.1]  | 19/11/2024   |
         | [3.23.0]  |     -        |
         | [3.22.1]  | 23/10/2024   |


### PR DESCRIPTION
- Add `3.23.2` to the version history
- Fix whitespace bug reported in [BE-4986](https://linear.app/appcircle/issue/BE-4986/tart-vm-run-command-multiline-problem)