### PR TITLE
BE-6322 Xcode 16.4 update

### DIFF
--- a/docs/infrastructure/ios-build-infrastructure.md
+++ b/docs/infrastructure/ios-build-infrastructure.md
@@ -32,19 +32,13 @@ Please note that virtual machines are wiped off after a build is executed (no ma
 
 ## Available Xcode Versions
 
-Our macOS build agents have Xcode versions 16.3.x, 16.2.x, 16.1.x, 16.0.x, 15.4.x, 15.3.x, 15.2.x, 15.1.x, 15.0.x, 14.3.x, 14.2.x, 14.1.x, 14.0.x, 13.4.x, 13.3.x, 13.2.x, 13.1.x, 13.0.x, 12.5.x available.
-
-:::caution
-
-- Xcode `14.3.x` or higher Xcode versions require a Mac running macOS Ventura 13.0 or later.
-- Xcode `16.3.x` or higher Xcode versions require a Mac running macOS Sequoia 15.2 or later.
-
-:::
+Our macOS build agents have Xcode versions 16.4.x, 16.3.x, 16.2.x, 16.1.x, 16.0.x, 15.4.x, 15.3.x, 15.2.x, 15.1.x, 15.0.x, 14.3.x, 14.2.x, 14.1.x, 14.0.x, 13.4.x, 13.3.x, 13.2.x, 13.1.x, 13.0.x, 12.5.x available.
 
 The "Appcircle Standard macOS Pool (arm64)" macOS **Sequoia** (`15.4.1`) stack has the Xcode versions below:
 
 | Version | Build |
 | ------- | ----- |
+| 16.4 | `16F6` |
 | 16.3 | `16E140` |
 | 16.2 | `16C5032a` |
 | 16.1 | `16B40` |


### PR DESCRIPTION
- Remove obsolete required macOS version caution from page