### PR TITLE
3.28.2 Docker/Podman self-hosted Appcircle server release

### DIFF
--- a/docs/self-hosted-appcircle/install-server/helm-chart/configuration/sensitive-configuration.md
+++ b/docs/self-hosted-appcircle/install-server/helm-chart/configuration/sensitive-configuration.md
@@ -55,7 +55,9 @@ kubectl create secret generic appcircle-server-auth-keycloak-passwords \
 :::caution
 Starting from the server version `3.28.2`, SMTP settings can be configured and updated directly from the Appcircle Dashboard. This is the recommended approach for managing SMTP settings as it allows you to update the configuration at any time without requiring server reset.
 
-See [Email Integration docs](/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/integration#configure-via-dashboard-recommended) for more details.
+See the [email integration](/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/integration#configure-via-dashboard-recommended) document for more information about the SMTP configuration.
+
+See the [version history](/self-hosted-appcircle/install-server/helm-chart/upgrades#version-history) to find out the minimum required Helm chart version for the server.
 :::
 
 If you prefer to configure SMTP via Kubernetes secrets during initial deployment:

--- a/docs/self-hosted-appcircle/install-server/helm-chart/installation/kubernetes.md
+++ b/docs/self-hosted-appcircle/install-server/helm-chart/installation/kubernetes.md
@@ -410,7 +410,9 @@ Starting from the server version `3.28.2`, SMTP settings can be configured and u
 1. Exclude the `global.mail` part from the `values.yaml` file.
 2. Configure SMTP settings on the Appcircle Dashboard after installation.
 
-See [Email Integration docs](/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/integration#configure-via-dashboard-recommended) for more details.
+See the [email integration](/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/integration#configure-via-dashboard-recommended) document for more information about the SMTP configuration.
+
+See the [version history](/self-hosted-appcircle/install-server/helm-chart/upgrades#version-history) to find out the minimum required Helm chart version for the server.
 :::
 
 ### 2. Remove Sensitive Information From `values.yaml`

--- a/docs/self-hosted-appcircle/install-server/helm-chart/installation/openshift.md
+++ b/docs/self-hosted-appcircle/install-server/helm-chart/installation/openshift.md
@@ -385,7 +385,9 @@ Starting from the server version `3.28.2`, SMTP settings can be configured and u
 1. Exclude the `global.mail` part from the `values.yaml` file.
 2. Configure SMTP settings on the Appcircle Dashboard after installation.
 
-See [Email Integration docs](/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/integration#configure-via-dashboard-recommended) for more details.
+See the [email integration](/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/integration#configure-via-dashboard-recommended) document for more information about the SMTP configuration.
+
+See the [version history](/self-hosted-appcircle/install-server/helm-chart/upgrades#version-history) to find out the minimum required Helm chart version for the server.
 :::
 
 ### 2. Remove Sensitive Information From `values.yaml`

--- a/docs/self-hosted-appcircle/install-server/linux-package/configure-server/advanced-configuration/container-engine-network-subnet.md
+++ b/docs/self-hosted-appcircle/install-server/linux-package/configure-server/advanced-configuration/container-engine-network-subnet.md
@@ -17,7 +17,7 @@ import NeedHelp from '@site/docs/\_need-help.mdx';
 This document explains how to configure your Appcircle server's and Appcircle DMZ server's network subnet of the containers if the existing subnet is conflicting with other networks or not suitable for your use case.
 
 :::info
-This feature is included in the Appcircle server package version **`3.28.0` or later**.
+This feature is included in the Appcircle server package version **`3.28.2` or later**.
 :::
 
 ## Configuring the Subnet for Appcircle Server

--- a/docs/self-hosted-appcircle/install-server/linux-package/update.md
+++ b/docs/self-hosted-appcircle/install-server/linux-package/update.md
@@ -63,6 +63,9 @@ For more information about the DMZ structure, you can check the [Appcircle DMZ d
 Below is the version history of the self-hosted Appcircle server. This table helps you track the latest updates and releases since your current version.
 
 <!-- Version Anchor Links -->
+[3.28.2]: https://docs.appcircle.io/release-notes#3-28-2
+[3.28.1]: https://docs.appcircle.io/release-notes#3-28-1
+[3.28.0]: https://docs.appcircle.io/release-notes#3-28-0
 [3.27.2]: https://docs.appcircle.io/release-notes#3-27-2
 [3.27.1]: https://docs.appcircle.io/release-notes#3-27-1
 [3.27.0]: https://docs.appcircle.io/release-notes#3-27-0
@@ -98,6 +101,9 @@ Below is the version history of the self-hosted Appcircle server. This table hel
         
         | Version   | Release Date |
         |-----------|--------------|
+        | [3.28.2]  | 17/07/2025   |
+        | [3.28.1]  |     -        |
+        | [3.28.0]  |     -        |
         |  3.27.3   | 21/05/2025   |
         | [3.27.2]  | 12/05/2025   |
         | [3.27.1]  |     -        |


### PR DESCRIPTION
- Add 3.28.2 to the Docker/Podman version history
- Bump some version info boxes to 3.28.2
  - Aligned with the latest release notes ✅ 
- Update Helm SMTP version cautions
  - Add link to the Helm chart version history