### PR TITLE
Add 3.28.3 to SH version history

### DIFF
--- a/docs/self-hosted-appcircle/install-server/linux-package/update.md
+++ b/docs/self-hosted-appcircle/install-server/linux-package/update.md
@@ -63,6 +63,7 @@ For more information about the DMZ structure, you can check the [Appcircle DMZ d
 Below is the version history of the self-hosted Appcircle server. This table helps you track the latest updates and releases since your current version.
 
 <!-- Version Anchor Links -->
+[3.28.3]: https://docs.appcircle.io/release-notes#3-28-3
 [3.28.2]: https://docs.appcircle.io/release-notes#3-28-2
 [3.28.1]: https://docs.appcircle.io/release-notes#3-28-1
 [3.28.0]: https://docs.appcircle.io/release-notes#3-28-0
@@ -101,6 +102,7 @@ Below is the version history of the self-hosted Appcircle server. This table hel
         
         | Version   | Release Date |
         |-----------|--------------|
+        | [3.28.3]  | 01/08/2025   |
         | [3.28.2]  | 17/07/2025   |
         | [3.28.1]  |     -        |
         | [3.28.0]  |     -        |


### PR DESCRIPTION
We have a new self-hosted version that should be in the Docker/Podman version history.