### PR TITLE
Bump runner version to 1.8.1

### DIFF
--- a/docs/self-hosted-appcircle/self-hosted-runner/cloud-providers/aws.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/cloud-providers/aws.md
@@ -308,13 +308,13 @@ cd "$HOME"
 Download the latest self-hosted runner package.
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-osx-arm64-1.8.0.zip
+unzip -o -u appcircle-runner-osx-arm64-1.8.1.zip
 ```
 
 Change directory into extracted `appcircle-runner` folder for following steps.

--- a/docs/self-hosted-appcircle/self-hosted-runner/installation.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/installation.md
@@ -102,13 +102,13 @@ Download the latest self-hosted runner package.
   <TabItem value="osx-arm64" label="macOS arm64" default>
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-osx-arm64-1.8.0.zip
+unzip -o -u appcircle-runner-osx-arm64-1.8.1.zip
 ```
 
   </TabItem>
@@ -116,13 +116,13 @@ unzip -o -u appcircle-runner-osx-arm64-1.8.0.zip
   <TabItem value="osx-x64" label="macOS x64">
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-osx-x64-1.8.0.zip
+unzip -o -u appcircle-runner-osx-x64-1.8.1.zip
 ```
 
   </TabItem>
@@ -130,13 +130,13 @@ unzip -o -u appcircle-runner-osx-x64-1.8.0.zip
   <TabItem value="linux-x64" label="Linux x64">
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-linux-x64-1.8.0.zip
+unzip -o -u appcircle-runner-linux-x64-1.8.1.zip
 ```
 
   </TabItem>

--- a/docs/self-hosted-appcircle/self-hosted-runner/update.md
+++ b/docs/self-hosted-appcircle/self-hosted-runner/update.md
@@ -21,26 +21,26 @@ Download and extract the latest self-hosted runner package.
   <TabItem value="osx-arm64" label="macOS arm64" default>
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-arm64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-osx-arm64-1.8.0.zip
+unzip -o -u appcircle-runner-osx-arm64-1.8.1.zip
 ```
 
   </TabItem>
   <TabItem value="osx-x64" label="macOS x64">
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-osx-x64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-osx-x64-1.8.0.zip
+unzip -o -u appcircle-runner-osx-x64-1.8.1.zip
 ```
 
   </TabItem>
@@ -48,13 +48,13 @@ unzip -o -u appcircle-runner-osx-x64-1.8.0.zip
   <TabItem value="linux-x64" label="Linux x64">
 
 ```bash
-curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.8.0.zip
+curl -O -L https://cdn.appcircle.io/self-hosted/runner/appcircle-runner-linux-x64-1.8.1.zip
 ```
 
 Extract self-hosted runner package.
 
 ```bash
-unzip -o -u appcircle-runner-linux-x64-1.8.0.zip
+unzip -o -u appcircle-runner-linux-x64-1.8.1.zip
 ```
 
   </TabItem>


### PR DESCRIPTION
Fixes missing runner version update in docs that should have been done previously.
- https://github.com/appcircleio/ac-runner-setup/commits/main/